### PR TITLE
feat(filter): add check state to hide clear all filters button

### DIFF
--- a/packages/admin-ui/src/filters/filter-group.state.tsx
+++ b/packages/admin-ui/src/filters/filter-group.state.tsx
@@ -1,14 +1,20 @@
+import { useMemo } from 'react'
 import type { GenericFilterStateReturn } from './filter/filter.state'
 
 export function useFilterGroupState(props: UseFilterGroupStateReturn) {
   const { filterStates, onClear: onClearCb } = props
+
+  const hasFilterApplied = useMemo(
+    () => filterStates.some((filterState) => filterState.hasFilterValueApplied),
+    [filterStates]
+  )
 
   const onClear = () => {
     filterStates.forEach((state) => state.onClear())
     onClearCb?.()
   }
 
-  return { onClear }
+  return { onClear, hasFilterApplied }
 }
 
 interface UseFilterGroupStateReturn {

--- a/packages/admin-ui/src/filters/filter-group.tsx
+++ b/packages/admin-ui/src/filters/filter-group.tsx
@@ -27,6 +27,7 @@ export function FilterGroup(props: FilterGroupProps) {
         onClick={state.onClear}
         variant="neutralTertiary"
         csx={{ marginLeft: '$space-2' }}
+        hidden={!state.hasFilterApplied}
       >
         {formatMessage('clearAll')}
       </Button>
@@ -36,5 +37,5 @@ export function FilterGroup(props: FilterGroupProps) {
 
 export interface FilterGroupProps extends SystemComponentProps<{}> {
   children?: ReactNode
-  state: { onClear: () => void }
+  state: { onClear: () => void; hasFilterApplied: boolean }
 }

--- a/packages/admin-ui/src/filters/filter-multiple/filter-multiple.state.tsx
+++ b/packages/admin-ui/src/filters/filter-multiple/filter-multiple.state.tsx
@@ -96,6 +96,7 @@ export function useFilterMultipleState<T extends AnyObject>(
     setMatches,
     deferredSearchValue,
     searchValue,
+    hasFilterValueApplied: !!appliedItems?.length,
   }
 }
 

--- a/packages/admin-ui/src/filters/filter/filter.state.tsx
+++ b/packages/admin-ui/src/filters/filter/filter.state.tsx
@@ -88,6 +88,7 @@ export function useFilterState<T extends AnyObject>(
     setMatches,
     deferredSearchValue,
     searchValue,
+    hasFilterValueApplied: !!appliedItem,
   }
 }
 
@@ -111,6 +112,7 @@ export interface GenericFilterStateReturn<T> {
   deferredSearchValue?: string
   matches: ItemList<T>
   setMatches: (items: ItemList<T>) => void
+  hasFilterValueApplied: boolean
 }
 
 export interface UseFilterStateReturn<T> extends GenericFilterStateReturn<T> {


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->
- Improve `FilterGroup` UX not showing the `Clear All` button when we don't have any filter applied.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
- Hide the clear all button when we don't have any filter applied

#### How should this be manually tested?
<!--- Usually `yarn and yarn test`, but feel encouraged to add a more descriptive explanation. -->
- Use `FilterGroup` and check if the `Clear All` button is showed only when we have values applied to filters

#### Screenshots or example usage

https://user-images.githubusercontent.com/23361175/213508219-29a1adf3-34f1-43d0-9b35-89b4c94bb816.mov


#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)
<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
