### PR TITLE
fix(theme): remove prefix customization from shoreline config definition

### DIFF
--- a/packages/next-docs/pages/api-reference/theme/config.mdx
+++ b/packages/next-docs/pages/api-reference/theme/config.mdx
@@ -10,6 +10,10 @@ export default defineConfig({
 })
 ```
 
+## `prefix`
+
+The namespace [prefix](/api-reference/csx/design-tokens#vendor-and-prefix) for the generated CSS. A shoreline config has the `sl` prefix.
+
 ## Options
 
 ### `preset`
@@ -78,19 +82,6 @@ The current working directory.
 ```ts filename="shoreline.config.ts"
 export default defineConfig({
   cwd: process.cwd(),
-})
-```
-
-### `prefix`
-
-The namespace [prefix](/api-reference/csx/design-tokens#vendor-and-prefix) for the generated CSS.
-
-- Type: `string`
-- Default: `undefined`
-
-```ts filename="shoreline.config.ts"
-export default defineConfig({
-  prefix: 'sl',
 })
 ```
 

--- a/packages/theme/src/config.ts
+++ b/packages/theme/src/config.ts
@@ -1,3 +1,4 @@
+import { constants } from '@vtex/shoreline-utils'
 import { findFile } from './find-file'
 import type { Presets } from './presets'
 import { lazyRuntime } from './typescript-runtime'
@@ -25,11 +26,13 @@ export interface ShorelineConfig {
   tokens?: Record<string, any>
 }
 
+type DefineConfigParams = Omit<ShorelineConfig, 'prefix'>
+
 /**
  * Define a Shoreline configuration
  */
-export function defineConfig(config: ShorelineConfig) {
-  return config
+export function defineConfig(config: DefineConfigParams = {}): ShorelineConfig {
+  return { prefix: constants.dsPrefix, ...config }
 }
 
 export function loadConfig(options: ConfigFileOptions): ConfigReturn {

--- a/packages/theme/src/presets/base.ts
+++ b/packages/theme/src/presets/base.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from '../config'
 
 export const presetBase = defineConfig({
-  prefix: 'sl',
   outdir: './shoreline',
   cwd: process.cwd(),
   tokens: {},

--- a/packages/theme/src/tests/config.test.ts
+++ b/packages/theme/src/tests/config.test.ts
@@ -1,24 +1,24 @@
 import { join } from 'path'
 import { defineConfig, isShorelineConfig, loadConfig } from '../config'
+import { constants } from '@vtex/shoreline-utils'
 
 describe('defineConfig', () => {
   it('should allow empty configs', () => {
-    const result = defineConfig({})
-    const expectation = {}
+    const result = defineConfig()
+    const expectation = { prefix: constants.dsPrefix }
 
     expect(result).toStrictEqual(expectation)
   })
 
   it('should allow filled configs', () => {
     const result = defineConfig({
-      prefix: 'sl',
       tokens: {
         radii: '8px',
       },
     })
 
     const expectation = {
-      prefix: 'sl',
+      prefix: constants.dsPrefix,
       tokens: {
         radii: '8px',
       },
@@ -52,7 +52,7 @@ describe('loadConfig', () => {
       cwd: join(__dirname, 'fixtures/js-config'),
     })
 
-    expect(result.prefix).toBe('js')
+    expect(result.prefix).toBe(constants.dsPrefix)
   })
 
   it('should load a ts config', () => {
@@ -60,6 +60,6 @@ describe('loadConfig', () => {
       cwd: join(__dirname, 'fixtures/ts-config'),
     })
 
-    expect(result.prefix).toBe('ts')
+    expect(result.prefix).toBe(constants.dsPrefix)
   })
 })

--- a/packages/theme/src/tests/fixtures/js-config/shoreline.config.js
+++ b/packages/theme/src/tests/fixtures/js-config/shoreline.config.js
@@ -1,5 +1,3 @@
 import { defineConfig } from '../../../config'
 
-export default defineConfig({
-  prefix: 'js',
-})
+export default defineConfig()

--- a/packages/theme/src/tests/fixtures/ts-config/shoreline.config.ts
+++ b/packages/theme/src/tests/fixtures/ts-config/shoreline.config.ts
@@ -1,5 +1,3 @@
 import { defineConfig } from '../../../config'
 
-export default defineConfig({
-  prefix: 'ts',
-})
+export default defineConfig()


### PR DESCRIPTION
<!-- If there is nothing to describe in some section, you can remove it -->

#### What is the purpose of this pull request?

<!--- Describe your changes in detail. -->

As the title says, it removes the ability to change the theme prefix when defining a shoreline configuration. This is necessary because it doesn't make sense to allow this kind of behavior for `shoreline` users.

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!--- Insert a GIF that best describes your mood after finishing your PR: ![](GIF URL) -->
