### PR TITLE
feat(theme): implement typography tokens

### DIFF
--- a/packages/csx/src/tests/csx.test.ts
+++ b/packages/csx/src/tests/csx.test.ts
@@ -153,3 +153,14 @@ test('@layer', () => {
     },
   })
 })
+
+test('text', () => {
+  expect(
+    csx({
+      text: '$text-body',
+    })
+  ).toStrictEqual({
+    font: 'var(--sl-text-body-font)',
+    letterSpacing: 'var(--sl-text-body-letter-spacing)',
+  })
+})

--- a/packages/csx/src/transforms.ts
+++ b/packages/csx/src/transforms.ts
@@ -1,3 +1,4 @@
+import { constants } from '@vtex/shoreline-utils'
 import type { CsxValue } from './csx-value'
 
 export const defaultTransformCollection: TransformCollection = {
@@ -22,7 +23,10 @@ export const defaultTransformCollection: TransformCollection = {
     zIndex: value.asCssVar(),
   }),
   text: (value) => ({
-    font: value.asCssVar(),
+    font: `var(--${constants.dsPrefix}-${value.asCleanToken()}-font)`,
+    letterSpacing: `var(--${
+      constants.dsPrefix
+    }-${value.asCleanToken()}-letter-spacing)`,
   }),
 
   /** DeepSearch values */

--- a/packages/theme/src/presets/admin.ts
+++ b/packages/theme/src/presets/admin.ts
@@ -384,55 +384,70 @@ export const presetAdmin = defineConfig({
       9: '800',
       10: '900',
     },
-    font: {
-      family: {
-        sans: '"Inter", -apple-system, system-ui, BlinkMacSystemFont, sans-serif',
-        mono: 'ui-monospace, Menlo, Monaco, "Cascadia Mono", "Segoe UI Mono", "Roboto Mono", "Oxygen Mono", "Ubuntu Monospace", "Source Code Pro", "Fira Mono", "Droid Sans Mono", "Courier New", monospace',
-      },
-      size: {
-        1: '0.75rem',
-        2: '0.875rem',
-        3: '1rem',
-        4: '1.25rem',
-        5: '1.5rem',
-      },
-      weight: {
-        hairline: '100',
-        thin: '200',
-        light: '300',
-        regular: '400',
-        medium: '500',
-        semibold: '600',
-        bold: '700',
-        black: '800',
-        ui: {
-          baseline: '$font-weight-medium',
-          strong: '$font-weight-semibold',
-          strongest: '$font-weight-bold',
-        },
-      },
-      'line-height': {
-        1: '1.3',
-        2: '1.5',
-      },
+    'font-family': {
+      sans: '"Inter", -apple-system, system-ui, BlinkMacSystemFont, sans-serif',
+    },
+    'font-weight': {
+      regular: '400',
+      medium: '500',
+      semibold: '600',
+    },
+    'font-size': {
+      1: '0.75rem',
+      2: '0.875rem',
+      3: '1rem',
+      4: '1.25rem',
+      5: '1.5rem',
+    },
+    'letter-spacing': {
+      normal: '0em',
+      tight: '-0.02em',
+      tighter: '-0.04em',
+    },
+    'line-height': {
+      normal: '1.4',
     },
     text: {
-      'page-title':
-        '$font-weight-ui-baseline $font-size-4 / $font-line-height-1 $font-family-sans',
-      title: {
-        1: '$font-weight-ui-strong $font-size-3 / $font-line-height-2 $font-family-sans',
-        2: '$font-weight-ui-baseline $font-size-3 / $font-line-height-2 $font-family-sans',
+      caption: {
+        2: {
+          font: '$font-weight-regular $font-size-1 / $line-height-normal $font-family-sans',
+          'letter-spacing': '$letter-spacing-normal',
+        },
+        1: {
+          font: '$font-weight-medium $font-size-1 / $line-height-normal $font-family-sans',
+          'letter-spacing': '$letter-spacing-normal',
+        },
       },
       action: {
-        1: '$font-weight-ui-strong $font-size-2 / $font-line-height-1 $font-family-sans',
-        2: '$font-weight-ui-baseline $font-size-2 / $font-line-height-1 $font-family-sans',
+        font: '$font-weight-semibold $font-size-2 / $line-height-normal $font-family-sans',
+        'letter-spacing': '$letter-spacing-normal',
       },
-      display:
-        '$font-weight-ui-strong $font-size-5 / $font-line-height-1 $font-family-sans',
-      body: '$font-weight-ui-baseline $font-size-2 / $font-line-height-1 $font-family-sans',
-      detail:
-        '$font-weight-ui-baseline $font-size-1 / $font-line-height-1 $font-family-sans',
-      code: '$font-weight-ui-baseline $font-size-2 / $font-line-height-1 $font-family-mono',
+      emphasis: {
+        font: '$font-weight-medium $font-size-2 / $line-height-normal $font-family-sans',
+        'letter-spacing': '$letter-spacing-normal',
+      },
+      body: {
+        font: '$font-weight-regular $font-size-2 / $line-height-normal $font-family-sans',
+        'letter-spacing': '$letter-spacing-normal',
+      },
+      display: {
+        4: {
+          font: '$font-weight-regular $font-size-3 / $line-height-normal $font-family-sans',
+          'letter-spacing': '$letter-spacing-tight',
+        },
+        3: {
+          font: '$font-weight-semibold $font-size-3 / $line-height-normal $font-family-sans',
+          'letter-spacing': '$letter-spacing-tight',
+        },
+        2: {
+          font: '$font-weight-semibold $font-size-4 / $line-height-normal $font-family-sans',
+          'letter-spacing': '$letter-spacing-tighter',
+        },
+        1: {
+          font: '$font-weight-semibold $font-size-5 / $line-height-normal $font-family-sans',
+          'letter-spacing': '$letter-spacing-tighter',
+        },
+      },
     },
   },
 })


### PR DESCRIPTION
This PR solves #967. This solution has two parts: 

### 1. We declare two entries on the text token sub-tree: `font` and `letter-spacing`. This will create a token for each leaf.

Shoreline.config.ts:

```ts
text: {
  [style]: {
    font: '...',
    'letter-spacing': '...'
  }
}
```

Generated CSS:

```css
:root {
  --sl-text-[style]-font: ...;
  --sl-text-[style]-letter-spacing: ...;
}
```

### 2. We make the text transformer to transform a single token into two tokens. 

```ts
csx({
  text: '$text-body',
})
```

Will generate:

```ts
{
  font: 'var(--sl-text-body-font)',
  letterSpacing: 'var(--sl-text-body-letter-spacing)'
}
```



#### Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly
