### PR TITLE
[PSO-668] Support to Safari (iOS v13.5)

### DIFF
--- a/packages/admin-ui/src/use-media-query/use-media-query.ts
+++ b/packages/admin-ui/src/use-media-query/use-media-query.ts
@@ -31,14 +31,24 @@ export function useMediaQuery(query: string | string[]): boolean[] {
           )
         )
 
-      mediaQuery.addEventListener('change', listener)
+      if (mediaQuery.addEventListener) {
+        mediaQuery.addEventListener('change', listener)
+      } else if (mediaQuery.addListener) {
+        // Compatibility to Safari (iOS: v13.5)
+        mediaQuery.addListener(listener)
+      }
 
       return listener
     })
 
     return () => {
       mediaQueryList.forEach((mediaQuery, index) => {
-        mediaQuery.removeEventListener('change', listenerList[index])
+        if (mediaQuery.removeEventListener) {
+          mediaQuery.removeEventListener('change', listenerList[index])
+        } else if (mediaQuery.removeListener) {
+          // Compatibility to Safari (iOS: v13.5)
+          mediaQuery.removeListener(listenerList[index])
+        }
       })
     }
   }, [query])


### PR DESCRIPTION
#### What is the purpose of this pull request?

- The admin-ui doesn't work at some Safari devices. I found that the problem is related to the `MediaQueryList#addEventListener` compatibility to older versions of the Safari.
- The origin: [CARD PSO-668](https://vtex-dev.atlassian.net/browse/PSO-668)

#### What problem is this solving?

- Fallback code to use the legacy web API MediaQueryList#addListener instead of MediaQueryList#addEventListener when necessary

#### How should this be manually tested?

1. You can try to load the builded code on some iOS 13.5. You can use the Browserstack with the iPad Air 2019.
2. The admin-ui docs sounds to be builded using the own admin-ui. You can open the https://admin-ui.vercel.app/guidelines/design-tokens on the iOS 13.5. Today it is broken.

#### Screenshots or example usage

### The admin-ui docs:

![Screenshot from 2023-10-18 11-51-16](https://github.com/vtex/shoreline/assets/8618687/887c2183-7b44-404f-b199-aca2cee891a0)

### The Sales app:
![Screenshot from 2023-10-18 11-52-22](https://github.com/vtex/shoreline/assets/8618687/eabb7cdd-f74d-4fb0-af02-fe50ad2e366b)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Quality improvement (tests or refactors)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (small fix or feature that doesn't impact functionalities)
- [ ] Requires change to documentation, which has been updated accordingly

#### How does this PR make you feel? [:link:](http://giphy.com/)

![](https://media3.giphy.com/media/QYRjw6Jz0jyr1AnPW9/giphy.gif?cid=ecf05e47k005wraa1829c6uxd15yfar52dd4jrzljkv0uv51&ep=v1_gifs_search&rid=giphy.gif&ct=g)
