### PR TITLE
Simple Table Selection

### DIFF
--- a/packages/components/src/simple-table/columns/get-selection-column.tsx
+++ b/packages/components/src/simple-table/columns/get-selection-column.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+
+import { Checkbox } from '../../checkbox'
+import { VisuallyHidden } from '../../visually-hidden'
+
+export function getSelectionColum<T>(): ColumnDef<T> {
+  return {
+    id: 'sl-selection-column',
+    header: ({ table }) => {
+      return (
+        <Checkbox
+          checked={table.getIsAllRowsSelected()}
+          indeterminate={table.getIsSomeRowsSelected()}
+          onChange={table.getToggleAllRowsSelectedHandler()}
+        >
+          <VisuallyHidden>Select</VisuallyHidden>
+        </Checkbox>
+      )
+    },
+    cell: ({ row }) => (
+      <Checkbox
+        checked={row.getIsSelected()}
+        disabled={!row.getCanSelect()}
+        indeterminate={row.getIsSomeSelected()}
+        onChange={row.getToggleSelectedHandler()}
+      >
+        <VisuallyHidden>{row.index}</VisuallyHidden>
+      </Checkbox>
+    ),
+  }
+}

--- a/packages/components/src/simple-table/columns/index.ts
+++ b/packages/components/src/simple-table/columns/index.ts
@@ -1,1 +1,2 @@
 export * from './get-expanded-column'
+export * from './get-selection-column'

--- a/packages/components/src/simple-table/simple-table.css
+++ b/packages/components/src/simple-table/simple-table.css
@@ -3,10 +3,6 @@
     width: 100%;
   }
 
-  [data-sl-table-row][data-selected='true'] {
-    background: var(--sl-bg-muted);
-  }
-
   [data-sl-detail-row] {
     background: var(--sl-bg-muted);
   }

--- a/packages/components/src/simple-table/simple-table.tsx
+++ b/packages/components/src/simple-table/simple-table.tsx
@@ -76,8 +76,8 @@ export const SimpleTable = forwardRef(function SimpleTable<T>(
         {table.getRowModel().rows.map((row) => (
           <Fragment key={row.id}>
             <TableRow
-              data-selected={row.getIsSelected()}
-              data-expanded={row.getIsExpanded()}
+              selected={row.getIsSelected()}
+              expanded={row.getIsExpanded()}
             >
               {row.getVisibleCells().map((cell) => (
                 <TableCell key={cell.id}>
@@ -86,7 +86,7 @@ export const SimpleTable = forwardRef(function SimpleTable<T>(
               ))}
             </TableRow>
             {row.getIsExpanded() && (
-              <TableRow data-sl-detail-row data-selected={row.getIsSelected()}>
+              <TableRow data-sl-detail-row selected={row.getIsSelected()}>
                 <TableCell
                   style={{
                     gridColumn: `1 / span ${row.getVisibleCells().length}`,

--- a/packages/components/src/simple-table/stories/selection.stories.tsx
+++ b/packages/components/src/simple-table/stories/selection.stories.tsx
@@ -24,8 +24,7 @@ import {
   MenuSeparator,
 } from '../../menu'
 import { VisuallyHidden } from '../../visually-hidden'
-import { SimpleTable } from '../index'
-import { Checkbox } from '../../checkbox'
+import { SimpleTable, getSelectionColum } from '../index'
 
 export default {
   title: 'shoreline-components/simple-table',
@@ -41,30 +40,7 @@ type Product = {
 export function Selection() {
   const columns = useMemo<Array<ColumnDef<Product>>>(
     () => [
-      {
-        id: 'select',
-        header: ({ table }) => {
-          return (
-            <Checkbox
-              checked={table.getIsAllRowsSelected()}
-              indeterminate={table.getIsSomeRowsSelected()}
-              onChange={table.getToggleAllRowsSelectedHandler()}
-            >
-              <VisuallyHidden>Select</VisuallyHidden>
-            </Checkbox>
-          )
-        },
-        cell: ({ row }) => (
-          <Checkbox
-            checked={row.getIsSelected()}
-            disabled={!row.getCanSelect()}
-            indeterminate={row.getIsSomeSelected()}
-            onChange={row.getToggleSelectedHandler()}
-          >
-            <VisuallyHidden>{row.index}</VisuallyHidden>
-          </Checkbox>
-        ),
-      },
+      getSelectionColum(),
       {
         id: 'name',
         cell: ({

--- a/packages/components/src/table/table-row.tsx
+++ b/packages/components/src/table/table-row.tsx
@@ -3,8 +3,21 @@ import React, { forwardRef } from 'react'
 
 export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
   function TableRow(props, ref) {
-    return <tr data-sl-table-row ref={ref} {...props} />
+    const { selected = false, expanded = false, ...otherProps } = props
+
+    return (
+      <tr
+        data-sl-table-row
+        data-selected={selected}
+        data-expanded={expanded}
+        ref={ref}
+        {...otherProps}
+      />
+    )
   }
 )
 
-export type TableRowProps = ComponentPropsWithoutRef<'tr'>
+export interface TableRowProps extends ComponentPropsWithoutRef<'tr'> {
+  selected?: boolean
+  expanded?: boolean
+}

--- a/packages/components/src/table/table.css
+++ b/packages/components/src/table/table.css
@@ -23,8 +23,11 @@
 
   [data-sl-table-header-cell],
   [data-sl-table-cell] {
-    color: var(--sl-color-fg);
     text-align: start;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    color: var(--sl-color-fg);
     padding: var(--sl-space-2);
     border-bottom: var(--sl-border);
   }
@@ -44,6 +47,10 @@
 
   [data-sl-table-row] {
     color: var(--sl-color-fg);
+
+    &[data-selected='true'] {
+      background: var(--sl-bg-muted);
+    }
   }
 
   [data-sl-table-cell] {


### PR DESCRIPTION
## Summary

Solves #1207 

## Example: API

Use the `getSelectionColumn` for ease of use

```jsx
const columns = [
  getSelectionColumn(),
  // ... other columns
]

<SimpleTable data={[]} columns={columns} />
```
