### PR TITLE
feat(simple-table): add row as link

### DIFF
--- a/packages/components/src/simple-table/simple-table.tsx
+++ b/packages/components/src/simple-table/simple-table.tsx
@@ -18,6 +18,8 @@ import {
   TableBody,
   TableCell,
 } from '../table'
+import type { NavigationTarget } from '../link-box/link-box-utils'
+import { LinkBox } from '../link-box'
 
 /**
  * Controlled table render built on top of TanStack/Table API
@@ -35,6 +37,7 @@ export const SimpleTable = forwardRef(function SimpleTable<T>(
     options,
     getRowCanExpand,
     renderDetail,
+    onRowClick,
     ...tableProps
   } = props
 
@@ -79,11 +82,33 @@ export const SimpleTable = forwardRef(function SimpleTable<T>(
               selected={row.getIsSelected()}
               expanded={row.getIsExpanded()}
             >
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                </TableCell>
-              ))}
+              {row.getVisibleCells().map((cell) => {
+                if (onRowClick && onRowClick.type === 'link') {
+                  const { getHref, target } = onRowClick
+
+                  return (
+                    <LinkBox
+                      href={getHref(row)}
+                      target={target}
+                      key={cell.id}
+                      asChild
+                    >
+                      <TableCell>
+                        {flexRender(
+                          cell.column.columnDef.cell,
+                          cell.getContext()
+                        )}
+                      </TableCell>
+                    </LinkBox>
+                  )
+                }
+
+                return (
+                  <TableCell key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </TableCell>
+                )
+              })}
             </TableRow>
             {row.getIsExpanded() && (
               <TableRow data-sl-detail-row selected={row.getIsSelected()}>
@@ -120,4 +145,17 @@ export interface SimpleTableProps<T> extends TableProps, TsMirrorProps<T> {
    * Renders function for the detail row
    */
   renderDetail?: (row: Row<T>) => ReactNode
+  /**
+   *
+   */
+  onRowClick?:
+    | {
+        type: 'link'
+        getHref: (row: Row<T>) => string
+        target?: NavigationTarget
+      }
+    | {
+        type: 'action'
+        onClick: (row: Row<T>) => void
+      }
 }

--- a/packages/components/src/simple-table/stories/detail.stories.tsx
+++ b/packages/components/src/simple-table/stories/detail.stories.tsx
@@ -11,7 +11,6 @@ import {
 } from '@vtex/shoreline-icons'
 import type { ColumnDef } from '@tanstack/react-table'
 
-import { Action } from '../../action'
 import { Flex } from '../../flex'
 import { Text } from '../../text'
 import { IconButton } from '../../icon-button'

--- a/packages/components/src/simple-table/stories/row-links.stories.tsx
+++ b/packages/components/src/simple-table/stories/row-links.stories.tsx
@@ -1,0 +1,51 @@
+import '../../../dist/styles.min.css'
+import '../simple-table.css'
+import React, { useMemo } from 'react'
+import type { ColumnDef } from '@tanstack/react-table'
+import { SimpleTable } from '../index'
+
+export default {
+  title: 'shoreline-components/simple-table',
+}
+
+interface Service {
+  name: string
+  url: string
+  price: string
+}
+
+const services: Service[] = [
+  { name: 'Vercel', url: 'https://vercel.com', price: '20 USD / Dev / Year' },
+  { name: 'Netlify', url: 'https://netlify.com', price: '19 USD / Dev / Year' },
+  { name: 'Azion', url: 'https://www.azion.com', price: '300 USD / Year' },
+]
+
+export function RowLinks() {
+  const columns = useMemo<Array<ColumnDef<Service>>>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: 'Service name',
+      },
+      {
+        accessorKey: 'price',
+        header: 'Price',
+      },
+    ],
+    []
+  )
+
+  return (
+    <SimpleTable
+      data={services}
+      columns={columns}
+      onRowClick={{
+        type: 'link',
+        getHref(row) {
+          return row.original.url
+        },
+        target: '_blank',
+      }}
+    />
+  )
+}


### PR DESCRIPTION
## Summary

Solves #1211 

## Examples

```jsx
<SimpleTable onRowClick={{ type: 'link', getRowLink: '', target: '_self' }} />
```
