### PR TITLE
Link component

### DIFF
--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -1,5 +1,6 @@
 /* PLOP_INJECT_EXPORT */
 export * from './clickable'
+export * from './link'
 export * from './link-box'
 export * from './pagination'
 export * from './popover'

--- a/packages/components/src/link/index.ts
+++ b/packages/components/src/link/index.ts
@@ -1,0 +1,1 @@
+export * from './link'

--- a/packages/components/src/link/link.css
+++ b/packages/components/src/link/link.css
@@ -1,0 +1,18 @@
+@layer sl-components {
+  [data-sl-link] {
+    font: inherit;
+    letter-spacing: inherit;
+    cursor: pointer;
+    text-decoration: none;
+    color: var(--sl-fg-accent);
+
+    &:visited {
+      color: var(--sl-fg-accent-pressed);
+    }
+
+    &:hover {
+      color: var(--sl-fg-accent-hover);
+      text-decoration: underline;
+    }
+  }
+}

--- a/packages/components/src/link/link.tsx
+++ b/packages/components/src/link/link.tsx
@@ -1,0 +1,27 @@
+import type { ComponentPropsWithoutRef } from 'react'
+import React, { forwardRef } from 'react'
+
+import { Compose } from '../compose'
+
+/**
+ * Anchor component
+ * @example
+ * <Link href="https://vtex.com">Go to VTEX</Link>
+ */
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(function Link(
+  props,
+  ref
+) {
+  const { asChild, ...otherProps } = props
+  const Comp = asChild ? Compose : 'a'
+
+  return <Comp data-sl-link ref={ref} {...otherProps} />
+})
+
+export interface LinkProps extends ComponentPropsWithoutRef<'a'> {
+  /**
+   * Enable children composition
+   * @default false
+   */
+  asChild?: boolean
+}

--- a/packages/components/src/link/stories/link.stories.tsx
+++ b/packages/components/src/link/stories/link.stories.tsx
@@ -1,0 +1,21 @@
+import '../../../dist/styles.min.css'
+import '../link.css'
+import React from 'react'
+
+import { Link } from '../index'
+import { Text } from '../../text'
+
+export default {
+  title: 'shoreline-components/link',
+}
+
+export function Default() {
+  return (
+    <Text>
+      Get smart about your digital commerce investments:
+      <Link href="https://vtex.com" target="_blank" rel="noreferer">
+        Get to know VTEX
+      </Link>
+    </Text>
+  )
+}

--- a/packages/components/src/link/tests/link.vitest.test.tsx
+++ b/packages/components/src/link/tests/link.vitest.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react'
+import { describe, expect, test } from 'vitest'
+import { render } from '@testing-library/react'
+
+import { Link } from '../link'
+
+describe('link', () => {
+  test('renders', () => {
+    const { container } = render(<Link href="https://vtex.com">Label</Link>)
+
+    expect(container.querySelector('[data-sl-link]')).toBeInTheDocument()
+  })
+})

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -1,6 +1,7 @@
 @import '../shoreline/styles.css';
 /* PLOP_INJECT_STYLES */
 @import './clickable/clickable.css';
+@import './link/link.css';
 @import './link-box/link-box.css';
 @import './pagination/pagination.css';
 @import './popover/popover.css';


### PR DESCRIPTION
## Summary

Link is a markup component for anchor `a`. It has composition to support use cases like Next/Link

## Examples

### Default

```jsx
<Link href="#">Label</Link>
```

### Composition with asChild

```jsx
import { Link } from '@vtex/shoreline-components'
import NextLink from 'next/link'

<Link href="#" asChild>
  <NextLink>Link from NextJS</NextLink>
</Link>
```
