### PR TITLE
refactor(radio): adjust style and change API to match checkbox

### DIFF
--- a/packages/components/src/radio/radio-group.tsx
+++ b/packages/components/src/radio/radio-group.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from 'react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import React, { forwardRef } from 'react'
 import type { RadioStore } from '@ariakit/react'
 import {
@@ -19,20 +19,23 @@ export const RadioGroup = forwardRef<HTMLInputElement, RadioGroupProps>(
       label,
       children,
       className,
-      direction,
+      direction = 'column',
       state,
       id: defaultId,
       ...otherProps
     } = props
 
     const id = useId(defaultId)
+    const stackGap = direction === 'column' ? '$space-4' : '$space-5'
 
     return (
       <RadioProvider store={state}>
-        <Field data-sl-radio-group className={className}>
+        <Field variant="group" data-sl-radio-group className={className}>
           <FieldLabel htmlFor={id}>{label}</FieldLabel>
           <BaseRadioGroup data-sl-group id={id} ref={ref} {...otherProps}>
-            <Stack direction={direction}>{children}</Stack>
+            <Stack direction={direction} space={stackGap}>
+              {children}
+            </Stack>
           </BaseRadioGroup>
           <FieldMessage
             error={error}
@@ -58,7 +61,7 @@ export interface RadioGroupProps extends ComponentPropsWithoutRef<'div'> {
   error?: boolean
   helpText?: string
   errorText?: string
-  label: string
+  label: ReactNode
   direction?: 'row' | 'column'
   state?: RadioStore
 }

--- a/packages/components/src/radio/radio.css
+++ b/packages/components/src/radio/radio.css
@@ -66,11 +66,11 @@
         --sl-element-border: var(--sl-border-critical-strong);
         --sl-element-border-hover: var(--sl-border-critical-strong-hover);
         --sl-element-bg: var(--sl-bg);
-        --sl-element-border-checked: var(--sl-border-critical-strong);
-        --sl-element-bg-checked: var(--sl-bg-critical-strong);
+        --sl-element-border-checked: var(--sl-bg-accent-strong);
+        --sl-element-bg-checked: var(--sl-bg-accent-strong);
         --sl-element-check-bg: var(--sl-bg);
-        --sl-element-focus-ring: var(--sl-focus-ring-critical);
-        --sl-element-focus-ring-checked: var(--sl-focus-ring-critical);
+        --sl-element-focus-ring: var(--sl-focus-ring);
+        --sl-element-focus-ring-checked: var(--sl-focus-ring-accent);
       }
 
       &:disabled {

--- a/packages/components/src/radio/radio.tsx
+++ b/packages/components/src/radio/radio.tsx
@@ -11,7 +11,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   const {
     error = false,
     disabled,
-    label,
+    children,
     value,
     id: defaultId,
     ...otherProps
@@ -22,7 +22,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
   return (
     <Field variant="control" data-sl-radio>
       <FieldLabel htmlFor={id} data-disabled={disabled}>
-        {label}
+        {children}
       </FieldLabel>
       <BaseRadio
         data-sl-radio-input
@@ -41,5 +41,4 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>(function Radio(
 export interface RadioProps extends ComponentPropsWithoutRef<'input'> {
   error?: boolean
   value: string
-  label: string
 }

--- a/packages/components/src/radio/stories/radio.stories.tsx
+++ b/packages/components/src/radio/stories/radio.stories.tsx
@@ -14,10 +14,16 @@ export default {
 export function Default() {
   return (
     <RadioGroup label="">
-      <Radio label="label" value="opt1" />
-      <Radio label="label" value="opt2" error />
-      <Radio label="label" value="opt3" disabled />
-      <Radio label="label" value="opt4" checked error disabled />
+      <Radio value="opt1">label</Radio>
+      <Radio value="opt2" error>
+        label
+      </Radio>
+      <Radio value="opt3" disabled>
+        label
+      </Radio>
+      <Radio value="opt4" checked error disabled>
+        label
+      </Radio>
     </RadioGroup>
   )
 }
@@ -26,16 +32,16 @@ export function RadioGroups() {
   return (
     <Stack>
       <RadioGroup label="Vertical radio group" errorText="Something is wrong">
-        <Radio label="Pen" value="opt1" />
-        <Radio label="Pinapple" value="opt2" />
-        <Radio label="Apple" value="opt3" />
-        <Radio label="Another pen" value="opt4" />
+        <Radio value="opt1">Pen</Radio>
+        <Radio value="opt2">Pineapple</Radio>
+        <Radio value="opt3">Apple</Radio>
+        <Radio value="opt4">Another pen</Radio>
       </RadioGroup>
       <RadioGroup label="Horizontal radio group" direction="row">
-        <Radio label="Pen" value="opt1" />
-        <Radio label="Pinapple" value="opt2" />
-        <Radio label="Apple" value="opt3" />
-        <Radio label="Another pen" value="opt4" />
+        <Radio value="opt1">Pen</Radio>
+        <Radio value="opt2">Pineapple</Radio>
+        <Radio value="opt3">Apple</Radio>
+        <Radio value="opt4">Another pen</Radio>
       </RadioGroup>
     </Stack>
   )
@@ -49,10 +55,10 @@ export function Error() {
         errorText="Something is wrong"
         error
       >
-        <Radio label="Pen" value="opt1" />
-        <Radio label="Pinapple" value="opt2" />
-        <Radio label="Apple" value="opt3" />
-        <Radio label="Another pen" value="opt4" />
+        <Radio value="opt1">Pen</Radio>
+        <Radio value="opt2">Pineapple</Radio>
+        <Radio value="opt3">Apple</Radio>
+        <Radio value="opt4">Another pen</Radio>
       </RadioGroup>
       <RadioGroup
         label="Horizontal radio group"
@@ -60,10 +66,10 @@ export function Error() {
         errorText="Something is wrong"
         error
       >
-        <Radio label="Pen" value="opt1" />
-        <Radio label="Pinapple" value="opt2" />
-        <Radio label="Apple" value="opt3" />
-        <Radio label="Another pen" value="opt4" />
+        <Radio value="opt1">Pen</Radio>
+        <Radio value="opt2">Pineapple</Radio>
+        <Radio value="opt3">Apple</Radio>
+        <Radio value="opt4">Another pen</Radio>
       </RadioGroup>
       <RadioGroup
         label="Horizontal radio group"
@@ -71,10 +77,46 @@ export function Error() {
         errorText="Something is wrong"
         error
       >
-        <Radio label="Pen" value="opt1" error />
-        <Radio label="Pinapple" value="opt2" error />
-        <Radio label="Apple" value="opt3" error />
-        <Radio label="Another pen" value="opt4" error />
+        <Radio value="opt1" error>
+          Pen
+        </Radio>
+        <Radio value="opt2" error>
+          Pineapple
+        </Radio>
+        <Radio value="opt3" error>
+          Apple
+        </Radio>
+        <Radio value="opt4" error>
+          Another pen
+        </Radio>
+      </RadioGroup>
+    </Stack>
+  )
+}
+
+export function Help() {
+  return (
+    <Stack>
+      <RadioGroup
+        label="Vertical radio group"
+        errorText="Something is wrong"
+        helpText="Pen pinapple apple pen"
+      >
+        <Radio value="opt1">Pen</Radio>
+        <Radio value="opt2">Pineapple</Radio>
+        <Radio value="opt3">Apple</Radio>
+        <Radio value="opt4">Another pen</Radio>
+      </RadioGroup>
+
+      <RadioGroup
+        label="Optional group (optional)"
+        errorText="Something is wrong"
+        helpText="Pen pinapple apple pen"
+      >
+        <Radio value="opt1">Pen</Radio>
+        <Radio value="opt2">Pineapple</Radio>
+        <Radio value="opt3">Apple</Radio>
+        <Radio value="opt4">Another pen</Radio>
       </RadioGroup>
     </Stack>
   )
@@ -104,10 +146,10 @@ export function Controlled() {
       state={state}
       helpText={helpText}
     >
-      <Radio label="Pen" value="opt1" />
-      <Radio label="Pinapple" value="opt2" />
-      <Radio label="Apple" value="opt3" />
-      <Radio label="Another pen" value="opt4" />
+      <Radio value="opt1">Pen</Radio>
+      <Radio value="opt2">Pineapple</Radio>
+      <Radio value="opt3">Apple</Radio>
+      <Radio value="opt4">Another pen</Radio>
     </RadioGroup>
   )
 }

--- a/packages/components/src/radio/tests/radio.vitest.test.tsx
+++ b/packages/components/src/radio/tests/radio.vitest.test.tsx
@@ -6,13 +6,13 @@ import { Radio } from '../radio'
 
 describe('radio', () => {
   test('renders', () => {
-    const { container } = render(<Radio label="label" value="id" />)
+    const { container } = render(<Radio value="id" >test</Radio>)
 
     expect(container.querySelector('[data-sl-radio]')).toBeInTheDocument()
   })
 
   test('renders field label', () => {
-    const { getByText } = render(<Radio label="label" value="id" />)
+    const { getByText } = render(<Radio value="id" >label</Radio>)
 
     expect(getByText('label')).toBeInTheDocument()
   })


### PR DESCRIPTION
## Summary

Changing style after design review was made + changing label prop to children so it matches with checkbox API

## Examples
```
<RadioGroup
      label="Vertical radio group"
      errorText="Something is wrong"
      state={state}  // optional
      helpText={helpText}
   >
      <Radio value="opt1">Pen</Radio>
      <Radio value="opt2">Pineapple</Radio>
      <Radio value="opt3">Apple</Radio>
      <Radio value="opt4">Another pen</Radio>
</RadioGroup>
```