### PR TITLE
feat(table): add density api

### DIFF
--- a/packages/components/src/table/stories/table.stories.tsx
+++ b/packages/components/src/table/stories/table.stories.tsx
@@ -14,13 +14,34 @@ import { LinkBox } from '../../link-box'
 
 export default {
   title: 'shoreline-components/table',
+  argTypes: {
+    density: {
+      description: 'Table density',
+      default: 'default',
+      options: ['default', 'comfortable', 'compact'],
+      control: { type: 'radio' },
+    },
+    columnWidths: {
+      description: 'Array of column widths',
+      options: [
+        ['minmax(min-content, auto)', 'minmax(min-content, auto)'],
+        ['1fr', '1fr'],
+        ['1fr', '2fr'],
+        ['2fr', '1fr'],
+      ],
+      control: { type: 'radio' },
+    },
+  },
 }
 
-export function Default() {
+export function Default(props) {
+  const {
+    density,
+    columnWidths = ['minmax(min-content, auto)', 'minmax(min-content, auto)'],
+  } = props
+
   return (
-    <Table
-      columnWidths={['minmax(min-content, auto)', 'minmax(min-content, auto)']}
-    >
+    <Table columnWidths={columnWidths} density={density}>
       <TableHeader>
         <TableRow>
           <TableHeaderCell>Name</TableHeaderCell>

--- a/packages/components/src/table/table.css
+++ b/packages/components/src/table/table.css
@@ -46,6 +46,27 @@
         }
       }
     }
+
+    &[data-sl-table-density='default'] {
+      [data-sl-table-header-cell],
+      [data-sl-table-cell] {
+        padding: var(--sl-space-2);
+      }
+    }
+
+    &[data-sl-table-density='comfortable'] {
+      [data-sl-table-header-cell],
+      [data-sl-table-cell] {
+        padding: var(--sl-space-1);
+      }
+    }
+
+    &[data-sl-table-density='compact'] {
+      [data-sl-table-header-cell],
+      [data-sl-table-cell] {
+        padding: var(--sl-space-0);
+      }
+    }
   }
 
   [data-sl-table-header],

--- a/packages/components/src/table/table.tsx
+++ b/packages/components/src/table/table.tsx
@@ -12,6 +12,7 @@ export const Table = forwardRef<HTMLDivElement, TableProps>(function Table(
     asChild = false,
     stickyHeader = false,
     stickyColumn = false,
+    density = 'default',
     style = {},
     ...otherProps
   } = props
@@ -24,6 +25,7 @@ export const Table = forwardRef<HTMLDivElement, TableProps>(function Table(
       data-sl-table
       data-sl-table-header-sticky={stickyHeader}
       data-sl-table-sticky-column={stickyColumn}
+      data-sl-table-density={density}
       ref={ref}
       style={
         {
@@ -49,6 +51,10 @@ export interface TableProps extends ComponentPropsWithoutRef<'div'> {
    * @default [repeat(${columns.length}, var(--sl-table-default-column-width))]
    */
   columnWidths?: string[]
+  /**
+   * If true, the Table component will be rendered as a child of the Compose component
+   * @default false
+   */
   asChild?: boolean
   /**
    * If true, the header will be sticky
@@ -60,4 +66,9 @@ export interface TableProps extends ComponentPropsWithoutRef<'div'> {
    * @default false
    */
   stickyColumn?: boolean
+  /**
+   * The density of the table
+   * @default 'default'
+   */
+  density?: 'default' | 'comfortable' | 'compact'
 }

--- a/packages/components/src/table/tests/table.vitest.test.tsx
+++ b/packages/components/src/table/tests/table.vitest.test.tsx
@@ -42,6 +42,9 @@ describe('table', () => {
     expect(
       container.querySelector(`[data-sl-table-sticky-column='false']`)
     ).toBeInTheDocument()
+    expect(
+      container.querySelector(`[data-sl-table-density='default']`)
+    ).toBeInTheDocument()
   })
 
   test('renders with sticky header', () => {


### PR DESCRIPTION
## Summary

Add table density API. Values and props will likely change once we have a visual for it.

Resolves #1213 

## Examples

```jsx
<Table density="default" />
```

```jsx
<SimpleTable density="comfortable" />
```

I have added a density control on the table's default story.