### PR TITLE
feat(i18n): add dynamic message functionality

### DIFF
--- a/packages/components/src/locale/tests/create-message-hook.vitest.test.tsx
+++ b/packages/components/src/locale/tests/create-message-hook.vitest.test.tsx
@@ -82,4 +82,52 @@ describe('create-message-hook', () => {
 
     expect(getByText('Palavra')).toBeInTheDocument()
   })
+
+  test('gets dynamic message', () => {
+    const messages = {
+      'en-US': {
+        pageLabel: '{page} of {pages}',
+      },
+    }
+
+    const useMessage = createMessageHook(messages)
+
+    const hook = renderHook(() => useMessage(), {
+      wrapper: ({ children }) => (
+        <LocaleProvider locale="en-US">{children}</LocaleProvider>
+      ),
+    })
+
+    const { getByText } = render(
+      <LocaleProvider locale="en-US">
+        <div>{hook.result.current('pageLabel', { page: 4, pages: 765 })}</div>
+      </LocaleProvider>
+    )
+
+    expect(getByText('4 of 765')).toBeInTheDocument()
+  })
+
+  test('fallbacks message value when dynamic message is not specified correctly', () => {
+    const messages = {
+      'en-US': {
+        pageLabel: '{page} of {pages}',
+      },
+    }
+
+    const useMessage = createMessageHook(messages)
+
+    const hook = renderHook(() => useMessage(), {
+      wrapper: ({ children }) => (
+        <LocaleProvider locale="en-US">{children}</LocaleProvider>
+      ),
+    })
+
+    const { getByText } = render(
+      <LocaleProvider locale="en-US">
+        <div>{hook.result.current('pageLabel', { page: 4 })}</div>
+      </LocaleProvider>
+    )
+
+    expect(getByText('4 of {pages}')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

* Add dynamic message values functionality
* Make it simple the message render logic

<!-- Explain the change motivation -->

## Examples

You can check the tests for a more detailed usage

``` jsx
const messages = { 'en-US': { pageLabel: "{page} of {pages}" }

const pageLabel = getMessage('pageLabel', variables: { page: 4, pages: 764 })
// 4 of 764
```
