### PR TITLE
feat(checkbox): remove different color scheme for error

### DIFF
--- a/packages/components/src/checkbox/checkbox-field.tsx
+++ b/packages/components/src/checkbox/checkbox-field.tsx
@@ -33,7 +33,6 @@ export const CheckboxField = forwardRef<HTMLDivElement, CheckboxFieldProps>(
         <Checkbox
           id={id}
           disabled={disabled}
-          error={error}
           ref={forwardedRef}
           {...ariaProps}
         />

--- a/packages/components/src/checkbox/checkbox-group.tsx
+++ b/packages/components/src/checkbox/checkbox-group.tsx
@@ -14,7 +14,7 @@ export const CheckboxGroup = forwardRef<HTMLInputElement, CheckboxGroupProps>(
       label,
       children,
       className,
-      direction,
+      direction = 'column',
       id: defaultId,
       ...otherProps
     } = props

--- a/packages/components/src/checkbox/checkbox.css
+++ b/packages/components/src/checkbox/checkbox.css
@@ -58,17 +58,6 @@
     }
 
     &[data-disabled='false'] {
-      &[data-error='true'] {
-        border: var(--sl-border-critical-strong);
-        &:hover {
-          border: var(--sl-border-critical-strong-hover);
-        }
-        &[data-focus-visible='true'] {
-          box-shadow: var(--sl-focus-ring-critical);
-          border: var(--sl-border-critical-strong-hover);
-        }
-      }
-
       &[data-checked='true'] {
         background: var(--sl-bg-accent-strong);
         border: var(--sl-border-accent-strong);
@@ -87,12 +76,6 @@
           border: var(--sl-border-accent-strong-hover);
         }
       }
-    }
-
-    &[data-error='true'][data-disabled='true'] {
-      color: var(--sl-fg-disabled);
-      background: var(--sl-bg-disabled);
-      border: var(--sl-border-disabled);
     }
   }
 }

--- a/packages/components/src/checkbox/checkbox.tsx
+++ b/packages/components/src/checkbox/checkbox.tsx
@@ -15,8 +15,6 @@ import './checkbox.css'
  */
 export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(
   function Checkbox(props, forwardedRef) {
-    const { error, ...ariaProps } = props
-
     const {
       inputProps,
       inputRef,
@@ -24,7 +22,7 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(
       isIndeterminate,
       isFocusVisible,
       isDisabled,
-    } = useAriaCheckbox(ariaProps)
+    } = useAriaCheckbox(props)
 
     return (
       <label data-sl-checkbox>
@@ -41,15 +39,14 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(
           data-indeterminate={isIndeterminate}
           data-disabled={isDisabled}
           data-focus-visible={isFocusVisible}
-          data-error={error}
           aria-hidden="true"
         >
           {isIndeterminate && <IconMinusSmall data-sl-checkbox-check-mixed />}
           {isChecked && <IconCheckSmall data-sl-checkbox-check />}
         </div>
-        {ariaProps.children ? (
+        {props.children ? (
           <Text data-sl-checkbox-label data-disabled={isDisabled}>
-            {ariaProps.children}
+            {props.children}
           </Text>
         ) : null}
       </label>
@@ -57,10 +54,4 @@ export const Checkbox = forwardRef<HTMLDivElement, CheckboxProps>(
   }
 )
 
-export interface CheckboxProps extends AriaCheckboxProps {
-  /**
-   * Whether the field contains an error or not
-   * @default false
-   */
-  error?: boolean
-}
+export type CheckboxProps = AriaCheckboxProps

--- a/packages/components/src/checkbox/stories/checkbox.stories.tsx
+++ b/packages/components/src/checkbox/stories/checkbox.stories.tsx
@@ -16,7 +16,6 @@ export function Default() {
   return (
     <Stack>
       <Checkbox>Label</Checkbox>
-      <Checkbox error>Label</Checkbox>
       <Checkbox disabled>Label</Checkbox>
     </Stack>
   )
@@ -43,9 +42,6 @@ export function Indeterminate() {
   return (
     <Stack>
       <Checkbox indeterminate>Indeterminate</Checkbox>
-      <Checkbox indeterminate error>
-        With error
-      </Checkbox>
       <Checkbox indeterminate disabled>
         Disabled
       </Checkbox>
@@ -99,12 +95,10 @@ export function Group() {
         <Checkbox disabled>None</Checkbox>
       </CheckboxGroup>
       <CheckboxGroup error label="Options" errorText="Bad choice">
-        <Checkbox error>Everything</Checkbox>
-        <Checkbox error>Everywhere</Checkbox>
-        <Checkbox error>All at once</Checkbox>
-        <Checkbox error disabled>
-          None
-        </Checkbox>
+        <Checkbox>Everything</Checkbox>
+        <Checkbox>Everywhere</Checkbox>
+        <Checkbox>All at once</Checkbox>
+        <Checkbox disabled>None</Checkbox>
       </CheckboxGroup>
       <CheckboxGroup
         error
@@ -117,10 +111,10 @@ export function Group() {
         helpText="Choose one of these"
         errorText="Bad choice"
       >
-        <Checkbox error>Everything</Checkbox>
-        <Checkbox error>Everywhere</Checkbox>
-        <Checkbox error>All at once</Checkbox>
-        <Checkbox error disabled>
+        <Checkbox>Everything</Checkbox>
+        <Checkbox>Everywhere</Checkbox>
+        <Checkbox>All at once</Checkbox>
+        <Checkbox disabled>
           None
         </Checkbox>
       </CheckboxGroup>
@@ -130,10 +124,10 @@ export function Group() {
         label="Options with error"
         errorText="Bad choice"
       >
-        <Checkbox error>Everything</Checkbox>
-        <Checkbox error>Everywhere</Checkbox>
-        <Checkbox error>All at once</Checkbox>
-        <Checkbox error disabled>
+        <Checkbox>Everything</Checkbox>
+        <Checkbox>Everywhere</Checkbox>
+        <Checkbox>All at once</Checkbox>
+        <Checkbox disabled>
           None
         </Checkbox>
       </CheckboxGroup>


### PR DESCRIPTION
## Summary

Adjustments after design changes + fix wrong gap space on vertical group layout

context: it's been decided that checkbox wont have a red color scheme in error state anylonger
