### PR TITLE
chore(cicd): add job to ask user to set the gh projects fields and pr labels

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -13,6 +13,8 @@ jobs:
   comment_pr:
     runs-on: ubuntu-latest
     name: Comment PR instructions
+    # only run this when PR is opened
+    if: github.event_name == 'pull_request' && github.event.action == 'opened'
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
Per title! This new job instructs PR authors to set the GH projects fields and PR labels. Automating GH projects field setting is a rather daunting task... It will take some time to achieve it with GitHub actions since we need to have our own GitHub App created for this. I've already requested the DX team to provision one for us a long time ago (see [Token from vtexgithubbot with scopes read:repo and read:project for the Admin Team](https://docs.google.com/document/d/1_2FNlQGvrDt_CwjEC4XE89kh_zi1pAjtBd27w5HxSyo/edit#heading=h.ox0107b5cr05)) but with no success. I will try again. If you're curious to learn more about how to fully automate GH projects with GH actions, see https://docs.github.com/en/issues/planning-and-tracking-with-projects/automating-your-project/automating-projects-using-actions.