### PR TITLE
Fix build error at shoreline-components package

### DIFF
--- a/packages/components/src/modal/modal-header.tsx
+++ b/packages/components/src/modal/modal-header.tsx
@@ -38,25 +38,21 @@ export const ModalHeader = forwardRef<HTMLDivElement, ModalHeaderProps>(
     const { children, ...otherProps } = props
 
     return (
-      <Content
-        as="header"
-        data-sl-modal-header
-        narrow
-        ref={ref}
-        {...otherProps}
-      >
-        <Flex justify="space-between">
-          <Heading asChild variant="display2">
-            <DialogHeading data-sl-modal-title>{children}</DialogHeading>
-          </Heading>
-          <Bleed vertical horizontal>
-            <IconButton variant="tertiary" label="close" asChild>
-              <DialogDismiss>
-                <IconX />
-              </DialogDismiss>
-            </IconButton>
-          </Bleed>
-        </Flex>
+      <Content asChild data-sl-modal-header narrow ref={ref} {...otherProps}>
+        <header>
+          <Flex justify="space-between">
+            <Heading asChild variant="display2">
+              <DialogHeading data-sl-modal-title>{children}</DialogHeading>
+            </Heading>
+            <Bleed vertical horizontal>
+              <IconButton variant="tertiary" label="close" asChild>
+                <DialogDismiss>
+                  <IconX />
+                </DialogDismiss>
+              </IconButton>
+            </Bleed>
+          </Flex>
+        </header>
       </Content>
     )
   }

--- a/packages/components/src/page/page-header.tsx
+++ b/packages/components/src/page/page-header.tsx
@@ -19,8 +19,10 @@ export const PageHeader = forwardRef<HTMLDivElement, PageHeaderProps>(
     const { children, ...otherProps } = props
 
     return (
-      <Content data-sl-page-header as="header" narrow ref={ref} {...otherProps}>
-        <Stack space="$space-3">{children}</Stack>
+      <Content data-sl-page-header asChild narrow ref={ref} {...otherProps}>
+        <header>
+          <Stack space="$space-3">{children}</Stack>
+        </header>
       </Content>
     )
   }


### PR DESCRIPTION
## Summary

It solves a problem of a unknown `as` property being used on the `ModalHeader` and the `PageHeader` components 
