### PR TITLE
fix(filter): extra padding after scss migration

### DIFF
--- a/packages/styles/src/filter/filter-popover.scss
+++ b/packages/styles/src/filter/filter-popover.scss
@@ -2,7 +2,7 @@
   margin-left: calc(-1 * var(--sl-space-1));
 }
 
-[data-sl-filter-popover] {
+[data-sl-filter-popover][data-sl-popover] {
   --sl-filter-popover-width: 16.25rem;
 
   width: var(--sl-filter-popover-width);


### PR DESCRIPTION
## Summary

Remove extra padding on filter popover

