### PR TITLE
fix(cicd): automated vercel deployment on main

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Generate Documentation
         run: |
           pnpm run gen:docs
-          git commit -am 'docs: generate documentation from "$GITHUB_SHA"' --allow-empty
+          git commit -am "docs: generate documentation from $GITHUB_SHA" --allow-empty
 
       - name: Publish
         run: pnpm lerna publish --yes --no-verify-access --conventional-graduate --force-publish


### PR DESCRIPTION
Fixes the always failing automated deployment to Vercel by randomly picking one of the admin team's engineer user name and email to config git on the CI and successfully deploy on Vercel

See https://github.com/orgs/vercel/discussions/2199

How to test this?
Simple. 

Create a file `test.sh` with the following content:
```sh
names=("anitavincent" "lucasaarcoverde" "marcelovicentegc" "matheusps")
emails=("anita.paes@vtex.com.br" "lucasaarcoverde@gmail.com" "marcelovicentegc@gmail.com" "matheus.procopio@vtex.com")

randomIndex=$(( RANDOM % ${#names[@]} ))
randomName=${names[randomIndex]}
randomEmail=${emails[randomIndex]}

echo $randomName
echo $randomEmail
```


And run `sh test.sh` on your terminal. You should see random people being picked up 😄 