### PR TITLE
feat: generate playground from storybook

### DIFF
--- a/.github/workflows/stable-release.yml
+++ b/.github/workflows/stable-release.yml
@@ -10,6 +10,8 @@ jobs:
     name: Shoreline
     timeout-minutes: 15
     runs-on: ubuntu-latest
+    outputs:
+      storybookUrl: ${{ steps.publish-to-chromatic.outputs.storybookUrl }}
 
     steps:
       - name: Check out code
@@ -52,19 +54,49 @@ jobs:
         run: pnpm test
 
       - name: Publish to Chromatic
+        id: publish-to-chromatic
         uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: build:storybook:ci
           exitOnceUploaded: true
 
-      - name: Generate Documentation
-        run: |
-          pnpm run gen:docs
-          git commit -am "docs: generate documentation from $GITHUB_SHA" --allow-empty
-
       - name: Publish
         run: pnpm lerna publish --yes --no-verify-access --conventional-graduate --force-publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           HUSKY: 0
+
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
+          fetch-depth: 25
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: 'pnpm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Generate Documentation
+        env:
+          STORYBOOK_URL: ${{needs.build.outputs.storybookUrl}}
+        run: |
+          pnpm run gen:docs
+          git commit -am "docs: generate documentation from $GITHUB_SHA" --allow-empty
+          git push -u origin main

--- a/packages/components/src/contextual-help/contextual-help.tsx
+++ b/packages/components/src/contextual-help/contextual-help.tsx
@@ -8,6 +8,7 @@ import { Container, Content } from '../content'
 /**
  * Merchants contextually understand the definition of an item through an overlay, that can be interactive, when clicking on the trigger.
  *
+ * @playground
  * @example
  * <ContextualHelp label="Meaningful label">
  *  Help message

--- a/packages/components/src/page/page.tsx
+++ b/packages/components/src/page/page.tsx
@@ -5,6 +5,7 @@ import { Container } from '../content'
 /**
  * Page containers allow merchants to identify where they are, view content related to a single main job, and perform related actions.
  *
+ * @playground
  * @example
  * <Page>
  *  <PageHeader>

--- a/packages/docs-generator/README.md
+++ b/packages/docs-generator/README.md
@@ -53,7 +53,8 @@ docs-generator
 ### For React components
 
 - Always provide a description for the component.
-- Always use the `@example` tag to provide examples of how to use the component. From this tag, a playground is generated.
+- Always use the `@example` tag to provide examples of how to use the component. This makes it easy for developers that look for documentation on the code itself.
+- Always use the `@playground` tag once you have written the playground for the component on Storybook following the [Best practices when writing Playgrounds with Storybook](#best-practices-when-writing-playgrounds-with-torybook). This makes our documentation site a powerful tool featuring live examples of how to use our components.
 - Always provide a description of each property of the component, including the `@default` value when necessary.
 
 Example:
@@ -62,6 +63,7 @@ Example:
 /**
  * Buttons triggers allow users to identify and start the most important actions in a container.
  *
+ * @playground
  * @example
  * <Button>Action label</Button>
  */
@@ -91,3 +93,8 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
     variant?: 'primary' | 'secondary' | 'tertiary'
 }
 ```
+
+## Best practices when writing Playgrounds with Storybook
+
+- Always use a `Playground` component to wrap your component. This component is responsible for rendering the component on a beautiful background.
+- Always write as much use cases as possible.

--- a/packages/docs-generator/src/handlers.ts
+++ b/packages/docs-generator/src/handlers.ts
@@ -85,15 +85,51 @@ export async function generateComponent(
     name: 'API Reference',
     description: func.signatures[0].comment.description,
     example: (() => {
-      const codeBlock = func.signatures[0].comment.blockTags.find(
-        (tag) => tag.name === 'example'
-      )?.text
+      if (!process.env.STORYBOOK_URL) {
+        const codeBlock = func.signatures[0].comment.blockTags.find(
+          (tag) => tag.name === 'example'
+        )?.text
 
-      if (!codeBlock) {
-        return false
+        if (!codeBlock) {
+          return false
+        }
+
+        return codeBlock.replace('```ts', '```jsx')
       }
 
-      return codeBlock.replace('```ts', '').replace('```', '')
+      const playgroundTag = func.signatures[0].comment.blockTags.find(
+        (tag) => tag.name === 'playground'
+      )?.text
+
+      if (typeof playgroundTag === 'undefined') {
+        const codeBlock = func.signatures[0].comment.blockTags.find(
+          (tag) => tag.name === 'example'
+        )?.text
+
+        if (!codeBlock) {
+          return false
+        }
+
+        return codeBlock.replace('```ts', '```jsx')
+      }
+
+      const storybookFeatures = '&full=1&shortcuts=false&singleStory=true'
+
+      const playgroundUrl = `${
+        process.env.STORYBOOK_URL
+      }?path=/story/shoreline-components-${toKebabCase(
+        func.name
+      )}--playground${storybookFeatures}`
+
+      const iframeStyles = {
+        width: '100%',
+        height: 600,
+        border: 0,
+        borderRadius: 4,
+      }
+
+      return `<iframe src="${playgroundUrl}" 
+        style={${JSON.stringify(iframeStyles)}}></iframe>`
     })(),
     parameters: func.signatures[0].parameters.map((param) => {
       return {

--- a/packages/docs-generator/src/templates/component.mdx.hbs
+++ b/packages/docs-generator/src/templates/component.mdx.hbs
@@ -7,10 +7,7 @@
 {{/if}}
 
 {{#if example}}
-
-```jsx
 {{{example}}}
-```
 {{/if}}
 
 {{#if parameters}}


### PR DESCRIPTION
Adds workflow to include storybook playgrounds (when existent) on the docs. When a storybook playground is not available, it fallbacks to the `@example` tag content provided that it also exists, otherwise none is displayed.

Here is a preview of how the embedded story playground looks like (it is only actually generated once a PR is merged to the main branch):

https://github.com/vtex/shoreline/assets/33183880/0d363cbd-10c7-4620-baea-1429b45481ab

Depends on:
- #1428 

