### PR TITLE
chore(ci/cd): add missing gh token to gh release workflow - ADMT-208

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
           pnpm lerna publish --preid rc --dist-tag rc --yes --force-publish --no-verify-access --conventional-commits --create-release github
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+          GH_TOKEN: ${{ secrets.VTEX_GITHUB_BOT_TOKEN }}
           HUSKY: 0
 
   docs:


### PR DESCRIPTION
The release workflow is missing due to a missing GH_TOKEN variable. This PR fixes this.

Follow up from #1533 