### PR TITLE
docs(site): add missing components examples

### DIFF
--- a/packages/docs/examples/filter.tsx
+++ b/packages/docs/examples/filter.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Filter, FilterItem } from '@vtex/shoreline'
+
+export default function Example() {
+  return (
+    <Filter label="Status">
+      <FilterItem value="Stable">Stable</FilterItem>
+      <FilterItem value="Experimental">Experimental</FilterItem>
+      <FilterItem value="Deprecated">Deprecated</FilterItem>
+    </Filter>
+  )
+}

--- a/packages/docs/examples/heading.tsx
+++ b/packages/docs/examples/heading.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Heading } from '@vtex/shoreline'
+
+export default function Example() {
+  return <Heading>Heading</Heading>
+}

--- a/packages/docs/examples/icon-button.tsx
+++ b/packages/docs/examples/icon-button.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { IconButton, IconTrash } from '@vtex/shoreline'
+
+export default function Example() {
+  return (
+    <IconButton label="Delete">
+      <IconTrash />
+    </IconButton>
+  )
+}

--- a/packages/docs/examples/input.tsx
+++ b/packages/docs/examples/input.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Input } from '@vtex/shoreline'
+
+export default function Example() {
+  return <Input />
+}

--- a/packages/docs/examples/label.tsx
+++ b/packages/docs/examples/label.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Label } from '@vtex/shoreline'
+
+export default function Example() {
+  return <Label>Label</Label>
+}

--- a/packages/docs/examples/link.tsx
+++ b/packages/docs/examples/link.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { Link } from '@vtex/shoreline'
+
+export default function Example() {
+  return (
+    <Link href="https://vtex.com" target="_blank">
+      VTEX site
+    </Link>
+  )
+}

--- a/packages/docs/examples/pagination.tsx
+++ b/packages/docs/examples/pagination.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import { Pagination } from '@vtex/shoreline'
+
+export default function Example() {
+  return <Pagination page={10} total={10} />
+}

--- a/packages/docs/examples/popover.tsx
+++ b/packages/docs/examples/popover.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+import { Popover, PopoverProvider, PopoverTrigger } from '@vtex/shoreline'
+
+export default function Example() {
+  return (
+    <PopoverProvider>
+      <PopoverTrigger>Trigger</PopoverTrigger>
+      <Popover>Content</Popover>
+    </PopoverProvider>
+  )
+}

--- a/packages/docs/examples/radio.tsx
+++ b/packages/docs/examples/radio.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Radio, RadioGroup } from '@vtex/shoreline'
+
+export default function Example() {
+  return (
+    <RadioGroup label="Radio group">
+      <Radio value="1">Option 1</Radio>
+      <Radio value="2">Option 2</Radio>
+      <Radio value="3">Option 3</Radio>
+    </RadioGroup>
+  )
+}

--- a/packages/docs/examples/select.tsx
+++ b/packages/docs/examples/select.tsx
@@ -1,0 +1,12 @@
+import React from 'react'
+import { Select } from '@vtex/shoreline'
+
+export default function Example() {
+  return (
+    <Select>
+      <option>option 1</option>
+      <option>option 2</option>
+      <option>option 3</option>
+    </Select>
+  )
+}

--- a/packages/docs/pages/components/filter.mdx
+++ b/packages/docs/pages/components/filter.mdx
@@ -2,11 +2,7 @@
 
 <ComponentDescription name="filter" />
 
-```jsx
-<Filter label="Label">
-  <FilterItem value="option">Option</FilterItem>
-</Filter>
-```
+<Preview name="filter" />
 
 ## Required props
 

--- a/packages/docs/pages/components/heading.mdx
+++ b/packages/docs/pages/components/heading.mdx
@@ -2,9 +2,7 @@
 
 <ComponentDescription name="heading" />
 
-```jsx
-<Heading>Headline text</Heading>
-```
+<Preview name="heading" />
 
 ## Optional props
 

--- a/packages/docs/pages/components/icon-button.mdx
+++ b/packages/docs/pages/components/icon-button.mdx
@@ -2,11 +2,7 @@
 
 <ComponentDescription name="icon-button" />
 
-```jsx
-<IconButton label="Delete">
-  <IconTrash />
-</IconButton>
-```
+<Preview name="icon-button" />
 
 ## Required props
 

--- a/packages/docs/pages/components/input.mdx
+++ b/packages/docs/pages/components/input.mdx
@@ -2,9 +2,7 @@
 
 <ComponentDescription name="input" />
 
-```jsx
-<Input />
-```
+<Preview name="input" />
 
 ## Optional props
 

--- a/packages/docs/pages/components/label.mdx
+++ b/packages/docs/pages/components/label.mdx
@@ -2,9 +2,7 @@
 
 <ComponentDescription name="label" />
 
-```jsx
-<Label>Label</Label>
-```
+<Preview name="label" />
 
 ## Optional props
 

--- a/packages/docs/pages/components/link.mdx
+++ b/packages/docs/pages/components/link.mdx
@@ -2,9 +2,7 @@
 
 <ComponentDescription name="link" />
 
-```jsx
-<Link href="https://vtex.com">Go to VTEX</Link>
-```
+<Preview name="link" />
 
 ## Optional props
 

--- a/packages/docs/pages/components/pagination.mdx
+++ b/packages/docs/pages/components/pagination.mdx
@@ -2,9 +2,7 @@
 
 <ComponentDescription name="pagination" />
 
-```jsx
-<Pagination page={page} onPageChange={(page, type) => {}} total={total} />
-```
+<Preview name="pagination" />
 
 ## Required props
 

--- a/packages/docs/pages/components/popover.mdx
+++ b/packages/docs/pages/components/popover.mdx
@@ -2,12 +2,7 @@
 
 <ComponentDescription name="popover" />
 
-```jsx
-<PopoverProvider>
-  <PopoverTrigger>Trigger</PopoverTrigger>
-  <Popover>Content</Popover>
-</PopoverProvider>
-```
+<Preview name="popover" />
 
 ## Optional props
 

--- a/packages/docs/pages/components/radio.mdx
+++ b/packages/docs/pages/components/radio.mdx
@@ -2,13 +2,7 @@
 
 <ComponentDescription name="radio" />
 
-```jsx
-<RadioGroup label="Radio group">
-  <Radio value="1">Option 1</Radio>
-  <Radio value="2">Option 2</Radio>
-  <Radio value="3">Option 3</Radio>
-</RadioGroup>
-```
+<Preview name="radio" />
 
 ## Required props
 

--- a/packages/docs/pages/components/select.mdx
+++ b/packages/docs/pages/components/select.mdx
@@ -2,13 +2,7 @@
 
 <ComponentDescription name="select" />
 
-```jsx
-<Select>
-  <option>option</option>
-  <option>option</option>
-  <option>option</option>
-</Select>
-```
+<Preview name="select" />
 
 ## Optional props
 


### PR DESCRIPTION
## Summary

Add missing components examples,  leaving only some primitives lacking a single example. Of course, we can add more examples for each component latter. 
