### PR TITLE
fix(fields): use bg base on form fields

### DIFF
--- a/packages/theme-sunrise/src/components/date-picker.scss
+++ b/packages/theme-sunrise/src/components/date-picker.scss
@@ -7,6 +7,7 @@
   --sl-datepicker-height: 2.75rem;
 
   display: inline-flex;
+  background: var(--sl-bg-base);
   height: var(--sl-datepicker-height);
   min-width: var(--sl-datepicker-min-width);
   font: var(--sl-text-action-font);

--- a/packages/theme-sunrise/src/components/date-range-picker.scss
+++ b/packages/theme-sunrise/src/components/date-range-picker.scss
@@ -13,6 +13,7 @@
   --sl-datepicker-height: 2.75rem;
 
   display: inline-flex;
+  background: var(--sl-bg-base);
   height: var(--sl-datepicker-height);
   min-width: var(--sl-datepicker-min-width);
   font: var(--sl-text-action-font);

--- a/packages/theme-sunrise/src/components/input.scss
+++ b/packages/theme-sunrise/src/components/input.scss
@@ -1,4 +1,5 @@
 [data-sl-input] {
+  background: var(--sl-bg-base);
   height: 2.75rem;
   width: 100%;
   font: var(--sl-text-body-font);

--- a/packages/theme-sunrise/src/components/table/table-header.scss
+++ b/packages/theme-sunrise/src/components/table/table-header.scss
@@ -1,4 +1,5 @@
 [data-sl-table-header] {
   display: contents;
   color: var(--sl-fg-base-soft);
+  background: var(--sl-bg-base);
 }

--- a/packages/theme-sunrise/src/components/time-input.scss
+++ b/packages/theme-sunrise/src/components/time-input.scss
@@ -2,6 +2,7 @@
   --sl-time-input-min-width: 20rem;
   --sl-time-input-height: 2.75rem;
 
+  background: var(--sl-bg-base);
   height: var(--sl-time-input-height);
   min-width: var(--sl-time-input-min-width);
   font: var(--sl-text-body-font);


### PR DESCRIPTION
## Summary

- Use the background base for fields, instead of transparent.
