### PR TITLE
docs: fix icon best practices text

### DIFF
--- a/packages/docs/pages/foundations/icons/best-practices.mdx
+++ b/packages/docs/pages/foundations/icons/best-practices.mdx
@@ -2,7 +2,7 @@
 
 Icons should communicate a message, so prioritize applying ones that are simple, easily recognizable, or well-established as conventions, and avoid metaphoric symbols.
 
-In Shoreline, they are identified by the prefix `Icon` and their naming convention is `Icon[IconName][Modifier]`. The IconName is always the same from the [Phosphor](https://phosphoricons.com/) library and the modifier can be related to weight or size. Since the default icons have a **Regular** size and an **Outline** weight, these modifiers won't be mentioned in their names. The modifiers **Fill** and **Small** are always specified. For example, the icon `IconTag` is regular and outlined, the icon `IconBellFill` is regular and filled, and the icon `IconCheckSmall` is small and outlined.
+In Shoreline, they are identified by the prefix `Icon` and their naming convention is `Icon[IconName][Modifier]`. The IconName is always the same from the [Phosphor](https://phosphoricons.com/) library and the modifier can be related to weight or size. Since the default icons have a **Normal** size and an **Outline** weight, these modifiers won't be mentioned in their names. The modifiers **Fill** and **Small** are always specified. For example, the icon `IconTag` is normal and outlined, the icon `IconBellFill` is normal and filled, and the icon `IconCheckSmall` is small and outlined.
 
 ## Modifiers
 
@@ -17,7 +17,7 @@ In Shoreline, they are identified by the prefix `Icon` and their naming conventi
 
 ![Icons size](public/assets/icons-size.webp)
 
-- **Regular:** Used in most scenarios, such as in a Button, Alert, Toast, and Sidebar sections. It is the default size, with a value of 20px.
+- **Normal:** Used in most scenarios, such as in a Button, Alert, Toast, and Sidebar sections. It is the default size, with a value of 20px.
 - **Small:** Used for affordance purposes, such as a caret in a Menu or Filter or an arrow on the right side of a label for external links. The size value is 16px.
 
 ## Usage
@@ -28,4 +28,4 @@ In Shoreline, they are identified by the prefix `Icon` and their naming conventi
 
 ## New icons
 
-As mentioned in the rationale, we strongly discourage custom icons to avoid unnecessary inconsistencies, but there are no solutions for your scenario in the Shoreline – Icons library or in the Phosphor library, reach out to the Admin team with a proposal for alignment.
+If you can't find an icon that fits your needs in the Shoreline – Icons library, follow the [contribution guidelines](https://shoreline.vtex.com/guides/processes) to request or propose a new icon. As mentioned in the rationale, we strongly discourage custom icons to avoid unnecessary inconsistencies, but if there are no solutions for your scenario in the Shoreline – Icons library or in the Phosphor library, start a discussion with a proposal for alignment.


### PR DESCRIPTION
Fix some parts of the Icons best practices text. Replaced `Regular` for `Normal`, and updated the `New icons` paragraph according to the InnerSource processes.