### PR TITLE
fix(collection-view): change to actions only appear if onError or onEmpty are passed

### DIFF
--- a/packages/shoreline/src/components/collection/collection-view.tsx
+++ b/packages/shoreline/src/components/collection/collection-view.tsx
@@ -57,19 +57,14 @@ export const CollectionView = forwardRef<HTMLDivElement, CollectionViewProps>(
       )
     }
 
+    const handleActionByStatus: Record<string, (() => void) | undefined> = {
+      error: onError,
+      empty: onEmpty,
+    }
+    const handleAction = handleActionByStatus[status]
     const heading = getMessage(`${status}-heading`)
     const description = getMessage(`${status}-description`)
-    const action = getMessage(`${status}-action`)
-
-    function handleAction() {
-      switch (status) {
-        case 'error':
-          return onError?.()
-
-        case 'empty':
-          return onEmpty?.()
-      }
-    }
+    const action = handleAction && getMessage(`${status}-action`)
 
     const actionVariant = status === 'empty' ? 'primary' : 'secondary'
 

--- a/packages/shoreline/src/components/collection/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/collection/stories/show.stories.tsx
@@ -99,6 +99,26 @@ export function Show() {
           <Pagination page={1} total={74} />
         </CollectionRow>
       </Collection>
+      {/* Error with action */}
+      <Collection>
+        <CollectionRow>
+          <Stack horizontal>
+            <Search />
+            <Filter label="Status">
+              <FilterItem value="Stable">Stable</FilterItem>
+              <FilterItem value="Experimental">Experimental</FilterItem>
+              <FilterItem value="Deprecated">Deprecated</FilterItem>
+            </Filter>
+          </Stack>
+          <Pagination page={1} total={74} />
+        </CollectionRow>
+        <CollectionView status="error" onError={() => alert('On empty action')}>
+          <div className="ready-view" />
+        </CollectionView>
+        <CollectionRow align="flex-end">
+          <Pagination page={1} total={74} />
+        </CollectionRow>
+      </Collection>
       {/* Empty */}
       <Collection>
         <CollectionRow>
@@ -113,6 +133,26 @@ export function Show() {
           <Pagination page={1} total={74} />
         </CollectionRow>
         <CollectionView status="empty">
+          <div className="ready-view" />
+        </CollectionView>
+        <CollectionRow align="flex-end">
+          <Pagination page={1} total={74} />
+        </CollectionRow>
+      </Collection>
+      {/* Empty with action */}
+      <Collection>
+        <CollectionRow>
+          <Stack horizontal>
+            <Search />
+            <Filter label="Status">
+              <FilterItem value="Stable">Stable</FilterItem>
+              <FilterItem value="Experimental">Experimental</FilterItem>
+              <FilterItem value="Deprecated">Deprecated</FilterItem>
+            </Filter>
+          </Stack>
+          <Pagination page={1} total={74} />
+        </CollectionRow>
+        <CollectionView status="empty" onEmpty={() => alert('On empty action')}>
           <div className="ready-view" />
         </CollectionView>
         <CollectionRow align="flex-end">

--- a/packages/shoreline/src/components/collection/tests/collections.test.tsx
+++ b/packages/shoreline/src/components/collection/tests/collections.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test, render } from '@vtex/shoreline-test-utils'
+import { describe, expect, test, render, vi } from '@vtex/shoreline-test-utils'
 
 import { Collection, CollectionView } from '../index'
 
@@ -52,8 +52,28 @@ describe('collection', () => {
     ).toBeInTheDocument()
   })
 
-  test('status error', () => {
+  test('status error without action', () => {
     const { container } = render(<CollectionView status="error" />)
+
+    expect(
+      container.querySelector('[data-sl-collection-view]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-sl-collection-view-heading]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-sl-collection-view-description]')
+    ).not.toBeInTheDocument()
+
+    expect(
+      container.querySelector('[data-sl-collection-view-action]')
+    ).not.toBeInTheDocument()
+  })
+
+  test('status error with action', () => {
+    const { container } = render(
+      <CollectionView status="error" onError={vi.fn()} />
+    )
 
     expect(
       container.querySelector('[data-sl-collection-view]')
@@ -70,8 +90,28 @@ describe('collection', () => {
     ).toBeInTheDocument()
   })
 
-  test('status empty', () => {
+  test('status empty without action', () => {
     const { container } = render(<CollectionView status="empty" />)
+
+    expect(
+      container.querySelector('[data-sl-collection-view]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-sl-collection-view-heading]')
+    ).toBeInTheDocument()
+    expect(
+      container.querySelector('[data-sl-collection-view-description]')
+    ).toBeInTheDocument()
+
+    expect(
+      container.querySelector('[data-sl-collection-view-action]')
+    ).not.toBeInTheDocument()
+  })
+
+  test('status empty with action', () => {
+    const { container } = render(
+      <CollectionView status="empty" onEmpty={vi.fn()} />
+    )
 
     expect(
       container.querySelector('[data-sl-collection-view]')


### PR DESCRIPTION
fix #1652

## Summary

<!-- Explain the change motivation -->
Explaned in the [issue](https://github.com/vtex/shoreline/issues/1652)

## Examples

<!-- Some code examples -->
![image](https://github.com/vtex/shoreline/assets/36760180/bd8debdf-5a2e-4fb7-8cfb-7cfc1010ffeb)

