### PR TITLE
fix(date-picker): change the border radius of the calendar IconButton

### DIFF
--- a/packages/shoreline/src/components/date-picker/date-picker.tsx
+++ b/packages/shoreline/src/components/date-picker/date-picker.tsx
@@ -55,6 +55,7 @@ export function DatePicker<T extends DateValue>(props: DatePickerProps<T>) {
           <Bleed end="$space-2">
             <PopoverTrigger asChild>
               <IconButton
+                data-sl-date-picker-button
                 id={buttonProps.id}
                 label={buttonProps['aria-label']}
                 aria-describedby={buttonProps['aria-describedby']}

--- a/packages/shoreline/src/themes/sunrise/components/date-picker.css
+++ b/packages/shoreline/src/themes/sunrise/components/date-picker.css
@@ -28,7 +28,7 @@
     border: var(--sl-border-base-strong-hover);
   }
 
-  &[data-error='true'] {
+  &[data-error="true"] {
     border: var(--sl-border-critical-strong);
 
     &:hover {
@@ -40,7 +40,7 @@
     }
   }
 
-  &[data-disabled='true'] {
+  &[data-disabled="true"] {
     border: var(--sl-border-base-disabled);
     color: var(--sl-fg-base-disabled);
     background-color: var(--sl-bg-base-disabled);
@@ -49,4 +49,8 @@
   &:focus {
     outline: none;
   }
+}
+
+[data-sl-date-picker-button] {
+  border-radius: var(--sl-radius-1);
 }


### PR DESCRIPTION
Border radius of calendar IconButton inside date picker input changed from `$radius-2` to `$radius-1`

fix #1583

## Examples

<img width="361" alt="image" src="https://github.com/vtex/shoreline/assets/55562946/843c74f9-706a-4fd5-8ed3-c41e42f46184">
