### PR TITLE
docs(broken links): update broken links in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,4 +31,4 @@ pnpm dev:docs # [docs package] runs the docs website
 ## Contribute to this repo
 
 Pull requests are welcome, please check our
-[development guideline](https://shoreline.vtex.com/guides/engineering-contribution/development-guideline)!
+[development guideline](https://shoreline.vtex.com/guides/code/development-guideline)!

--- a/packages/docs/pages/guides/code/development-guideline.mdx
+++ b/packages/docs/pages/guides/code/development-guideline.mdx
@@ -30,21 +30,21 @@ pnpm dev:storybook
 
 ### Development
 
-You can follow the [Component model guideline](/guides/engineering-contribution/component-model) as a guidance to develop your component. There you will understand how to structure your component, whether they have state, composition, or just a simple component.
+You can follow the [Component model guideline](/guides/code/component-model) as a guidance to develop your component. There you will understand how to structure your component, whether they have state, composition, or just a simple component.
 
 </Steps>
 
 ## Write Storybook stories
 
-You can check [our guideline](/guides/engineering-contribution/storybook-guideline) to understand how to write Storybook stories for Shoreline components.
+You can check [our guideline](/guides/code/storybook-guideline) to understand how to write Storybook stories for Shoreline components.
 
 ## Write documentation
 
-You can check [our guideline](/guides/engineering-contribution/documentation-guideline) to understand how to write Shoreline's documentation.
+You can check [our guideline](/guides/code/documentation-guideline) to understand how to write Shoreline's documentation.
 
 ## Write tests
 
-You can check [our guideline](/guides/engineering-contribution/test-guideline) to understand how to write Shoreline's tests.
+You can check [our guideline](/guides/code/test-guideline) to understand how to write Shoreline's tests.
 
 ## Commit convention
 

--- a/packages/docs/pages/guides/contributing-introduction.mdx
+++ b/packages/docs/pages/guides/contributing-introduction.mdx
@@ -26,8 +26,8 @@ Check out the [How to Contribute section](/guides/how-to-contribute) to understa
 Although most of the contributions are made through Github, the changes can also be applied to our Figma library.
 It doesn't matter if you are a designer or an engineer, you can contribute in both paths.
 
-* Check out the [Engineering contribution section](/guides/engineering-contribution/development-guideline) if you want to make changes to the codebase.
-* Check out the [Design contribution section](/guides/design-contribution/handoff-requirements) if you want to make changes to the Figma library.
+- Check out the [Engineering contribution section](/guides/code/development-guideline) if you want to make changes to the codebase.
+- Check out the [Design contribution section](/guides/design/handoff-requirements) if you want to make changes to the Figma library.
 
 ## Contribution categories
 

--- a/packages/docs/pages/guides/design/handoff-requirements.mdx
+++ b/packages/docs/pages/guides/design/handoff-requirements.mdx
@@ -9,7 +9,7 @@ import { Steps } from 'nextra/components'
 <Steps>
 ### Structure and documentation
 
-Component structure, library and website documentation following the [component guidelines](https://shoreline.vtex.comguides/design-contribution/component).
+Component structure, library and website documentation following the [component guidelines](https://shoreline.vtex.comguides/design/component).
 
 ### Branch in Figma library
 
@@ -36,17 +36,16 @@ Ask yourself which aspects of the component may cause doubts during implementati
 
 </Steps>
 
-
 ## New icon
 
 <Steps>
 ### Structure and documentation
 
-Icon structure and library documentation following the [icon guidelines](https://shoreline.vtex.comguides/design-contribution/icon).
+Icon structure and library documentation following the [icon guidelines](https://shoreline.vtex.comguides/design/icon).
 
 ### Branch in Figma library
 
-Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn2lIfmXBkHd9aXi/Shoreline-%E2%80%93-Icons?type=design&t=2tKhLTdmAl3dOZBm-6) Figma library adding the new icon with the name *Add [Icon name]* or *Update [Icon name]*.
+Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn2lIfmXBkHd9aXi/Shoreline-%E2%80%93-Icons?type=design&t=2tKhLTdmAl3dOZBm-6) Figma library adding the new icon with the name _Add [Icon name]_ or _Update [Icon name]_.
 
 </Steps>
 
@@ -56,11 +55,11 @@ Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn
 
 ### Structure and documentation
 
-Component or icon fix follows the [component](https://shoreline.vtex.comguides/design-contribution/component) or [icon](https://shoreline.vtex.comguides/design-contribution/icon) guidelines.
+Component or icon fix follows the [component](https://shoreline.vtex.comguides/design/component) or [icon](https://shoreline.vtex.comguides/design/icon) guidelines.
 
 ### Branch in Figma library
 
-Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn2lIfmXBkHd9aXi/Shoreline-%E2%80%93-Icons?type=design&t=2tKhLTdmAl3dOZBm-6) or [Shoreline – Components](https://www.figma.com/file/PWGSQ26U55u8E34JWn9ZYE/Shoreline-%E2%80%93-Components?type=design) Figma library including the bug fix with the name *Fix [Component or Icon]*.
+Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn2lIfmXBkHd9aXi/Shoreline-%E2%80%93-Icons?type=design&t=2tKhLTdmAl3dOZBm-6) or [Shoreline – Components](https://www.figma.com/file/PWGSQ26U55u8E34JWn9ZYE/Shoreline-%E2%80%93-Components?type=design) Figma library including the bug fix with the name _Fix [Component or Icon]_.
 
 </Steps>
 
@@ -70,14 +69,14 @@ Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn
 
 ### Structure and documentation
 
-Component or icon fix follows the [component](https://shoreline.vtex.comguides/design-contribution/component) or [icon](https://shoreline.vtex.comguides/design-contribution/icon) guidelines.
+Component or icon fix follows the [component](https://shoreline.vtex.comguides/design/component) or [icon](https://shoreline.vtex.comguides/design/icon) guidelines.
 
 ### Branch in Figma library
 
-Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn2lIfmXBkHd9aXi/Shoreline-%E2%80%93-Icons?type=design&t=2tKhLTdmAl3dOZBm-6) or [Shoreline – Components](https://www.figma.com/file/PWGSQ26U55u8E34JWn9ZYE/Shoreline-%E2%80%93-Components?type=design) Figma library including the bug fix with the name *Fix [Component or Icon]*.
+Create a branch in the [Shoreline – Icons](https://www.figma.com/file/o3s49SJn2lIfmXBkHd9aXi/Shoreline-%E2%80%93-Icons?type=design&t=2tKhLTdmAl3dOZBm-6) or [Shoreline – Components](https://www.figma.com/file/PWGSQ26U55u8E34JWn9ZYE/Shoreline-%E2%80%93-Components?type=design) Figma library including the bug fix with the name _Fix [Component or Icon]_.
 
 ### Specs file
 
-If it is a component, follow the same [specs guidelines](https://shoreline.vtex.com/guides/design-contribution/handoff-requirements#specs-file) from a new component.
+If it is a component, follow the same [specs guidelines](https://shoreline.vtex.com/guides/design/handoff-requirements#specs-file) from a new component.
 
 </Steps>

--- a/packages/docs/pages/guides/getting-started.mdx
+++ b/packages/docs/pages/guides/getting-started.mdx
@@ -47,7 +47,7 @@ Now that you are all set, you can start building your project with Shoreline. Ch
 <Cards>
 
 <Card title="Styling" href="guides/styling/introduction" />
-<Card title="Theming" href="guides/theming/introduction" />
+<Card title="Theming" href="guides/theming/css-package" />
 <Card title="Components" href="../components" />
 <Card title="Foundations" href="../foundations" />
 

--- a/packages/docs/pages/guides/how-to-contribute.mdx
+++ b/packages/docs/pages/guides/how-to-contribute.mdx
@@ -42,8 +42,9 @@ Get feedback through comments on the GitHub issue, on Figma, or by attending off
 
 As the discussions and refinements occur, your issue can be classified by a maintainer as valid to
 be resolved or not. If it is valid, these are the following steps:
+
 - **Figma bugs:** Prepare the handoff following the
-[guidelines](https://shoreline.vtex.com/guides/design-contribution/handoff-requirements) and post the files in the issue. A maintainer will review, approve, and merge the component or icon branch in the Figma library.
+  [guidelines](https://shoreline.vtex.com/guides/design/handoff-requirements) and post the files in the issue. A maintainer will review, approve, and merge the component or icon branch in the Figma library.
 - **Code bugs:** A maintainer will review and approve the solution.
 
 When the issue is in great shape and includes the necessary information and/or files to be implemented, it will be moved to the [Shoreline Backlog](http://localhost:3000/guides/how-to-contribute#shoreline-backlog) by a maintainer.
@@ -89,8 +90,9 @@ As you make progress, make sure to update your issue.
 
 As the discussions and refinements occur, your issue can be classified by a maintainer as valid to
 be resolved or not. If it is valid, these are the following steps:
+
 - **Design proposal:** Prepare the handoff following the
-[guidelines](https://shoreline.vtex.com/guides/design-contribution/handoff-requirements) and post the files in the issue. A maintainer will review, approve, and merge the component or icon branch in the Figma library.
+  [guidelines](https://shoreline.vtex.com/guides/design/handoff-requirements) and post the files in the issue. A maintainer will review, approve, and merge the component or icon branch in the Figma library.
 - **Code proposal:** A maintainer will review and approve the solution.
 
 When the issue is in great shape and includes the necessary information and/or files to be implemented, it will be moved to the [Shoreline Backlog](http://localhost:3000/guides/how-to-contribute#shoreline-backlog) by a maintainer.

--- a/packages/docs/pages/guides/styling/introduction.mdx
+++ b/packages/docs/pages/guides/styling/introduction.mdx
@@ -4,6 +4,6 @@ import { Steps } from 'nextra/components'
 
 This documentation aims to explain how the styling using shoreline components works. It is intended for developers who want to customize the look and feel of applications.
 
-By default every component doesn't have any style applied. Instead they have an architecture that respond to the `data-attributes` and `tokens` defined in the [Theme](/guides/theming/introduction). 
+By default every component doesn't have any style applied. Instead they have an architecture that respond to the `data-attributes` and `tokens` defined in the [Theme](/guides/theming/css-package).
 
 In the next sections you will understand how this architecture works and how to use it to create your own styles. 


### PR DESCRIPTION
## Summary

Fix some broken doc links.

## Examples

- https://shoreline.vtex.com/guides/theming/introduction
- https://shoreline.vtex.com/guides/engineering-contribution/development-guideline
