### PR TITLE
fix(search): add traslation for default placeholder of search component

### DIFF
--- a/packages/shoreline/src/components/search/messages/bg.json
+++ b/packages/shoreline/src/components/search/messages/bg.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/de.json
+++ b/packages/shoreline/src/components/search/messages/de.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/en.json
+++ b/packages/shoreline/src/components/search/messages/en.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/es.json
+++ b/packages/shoreline/src/components/search/messages/es.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/fr.json
+++ b/packages/shoreline/src/components/search/messages/fr.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/index.ts
+++ b/packages/shoreline/src/components/search/messages/index.ts
@@ -1,0 +1,27 @@
+import bg from './bg.json'
+import de from './de.json'
+import en from './en.json'
+import es from './es.json'
+import fr from './fr.json'
+import it from './it.json'
+import ja from './ja.json'
+import ko from './ko.json'
+import nl from './nl.json'
+import pt from './pt.json'
+import ro from './ro.json'
+import th from './th.json'
+
+export const messages = {
+  'en-US': en,
+  'es-AR': es,
+  'fr-FR': fr,
+  'pt-BR': pt,
+  'ja-JP': ja,
+  'ko-KR': ko,
+  'it-IT': it,
+  'nl-NL': nl,
+  'ro-RO': ro,
+  'bg-BG': bg,
+  'th-TH': th,
+  'de-DE': de,
+}

--- a/packages/shoreline/src/components/search/messages/it.json
+++ b/packages/shoreline/src/components/search/messages/it.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/ja.json
+++ b/packages/shoreline/src/components/search/messages/ja.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/ko.json
+++ b/packages/shoreline/src/components/search/messages/ko.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/nl.json
+++ b/packages/shoreline/src/components/search/messages/nl.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/pt.json
+++ b/packages/shoreline/src/components/search/messages/pt.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Pesquisar"
+}

--- a/packages/shoreline/src/components/search/messages/ro.json
+++ b/packages/shoreline/src/components/search/messages/ro.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/messages/th.json
+++ b/packages/shoreline/src/components/search/messages/th.json
@@ -1,0 +1,3 @@
+{
+  "placeholder": "Search"
+}

--- a/packages/shoreline/src/components/search/search.tsx
+++ b/packages/shoreline/src/components/search/search.tsx
@@ -5,6 +5,10 @@ import { IconMagnifyingGlassSmall, IconXCircle } from '../../icons'
 import { useId, useMergeRef } from '@vtex/shoreline-utils'
 import { Spinner } from '../spinner'
 import { VisuallyHidden } from '../visually-hidden'
+import { createMessageHook } from '../locale'
+import { messages } from './messages'
+
+const useMessage = createMessageHook(messages)
 
 /**
  * Search is a text input that users can type to narrow down a Collection. Use Filters if values can be classified in predefined options.
@@ -17,7 +21,7 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
     const {
       disabled = false,
       loading = false,
-      placeholder = 'Search',
+      placeholder,
       className,
       value,
       onClear,
@@ -25,6 +29,8 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
       defaultValue,
       ...inputProps
     } = props
+
+    const getMessage = useMessage(placeholder ? { placeholder } : undefined)
 
     const id = useId(defaultId)
 
@@ -55,12 +61,12 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
           ref={useMergeRef(ref, forwardedRef)}
           disabled={disabled}
           value={value}
-          placeholder={placeholder}
+          placeholder={getMessage('placeholder')}
           defaultValue={defaultValue}
           {...inputProps}
         />
         <VisuallyHidden>
-          <label htmlFor={id}>{placeholder}</label>
+          <label htmlFor={id}>{getMessage('placeholder')}</label>
         </VisuallyHidden>
         {!disabled &&
         (value || defaultValue) &&

--- a/packages/shoreline/src/components/search/search.tsx
+++ b/packages/shoreline/src/components/search/search.tsx
@@ -14,23 +14,25 @@ const useMessage = createMessageHook(messages)
  * Search is a text input that users can type to narrow down a Collection. Use Filters if values can be classified in predefined options.
  * @status stable
  * @example
- * <Search placeholder="Search" />
+ * <Search />
  */
 export const Search = forwardRef<HTMLInputElement, SearchProps>(
   function Search(props, forwardedRef) {
     const {
       disabled = false,
       loading = false,
-      placeholder,
+      messages,
       className,
       value,
       onClear,
+      placeholder: deprecatedPlaceholder,
       id: defaultId,
       defaultValue,
       ...inputProps
     } = props
 
-    const getMessage = useMessage(placeholder ? { placeholder } : undefined)
+    const getMessage = useMessage(messages)
+    const placeholder = deprecatedPlaceholder ?? getMessage('placeholder')
 
     const id = useId(defaultId)
 
@@ -61,12 +63,12 @@ export const Search = forwardRef<HTMLInputElement, SearchProps>(
           ref={useMergeRef(ref, forwardedRef)}
           disabled={disabled}
           value={value}
-          placeholder={getMessage('placeholder')}
+          placeholder={placeholder}
           defaultValue={defaultValue}
           {...inputProps}
         />
         <VisuallyHidden>
-          <label htmlFor={id}>{getMessage('placeholder')}</label>
+          <label htmlFor={id}>{placeholder}</label>
         </VisuallyHidden>
         {!disabled &&
         (value || defaultValue) &&
@@ -96,6 +98,21 @@ export interface SearchOptions {
    * @default undefined
    */
   onClear?: () => void
+  /**
+   * Object containing all messages to be displayed in the search input
+   */
+  messages?: {
+    /**
+     * Input placeholder text.
+     */
+    placeholder?: string
+  }
+  /**
+   * @deprecated
+   * You must use the messages property to override the placeholder label.
+   */
+  placeholder?: string
 }
 
-export type SearchProps = SearchOptions & ComponentPropsWithoutRef<'input'>
+export type SearchProps = SearchOptions &
+  Omit<ComponentPropsWithoutRef<'input'>, 'placeholder'>

--- a/packages/shoreline/src/components/search/stories/play.stories.tsx
+++ b/packages/shoreline/src/components/search/stories/play.stories.tsx
@@ -7,15 +7,17 @@ export default {
     value: {
       control: 'text',
     },
-    placeholder: {
-      control: 'text',
-      default: 'Change me',
+    messages: {
+      control: 'object',
     },
     disabled: { control: 'boolean', default: false },
     loading: { control: 'boolean', default: false },
   },
   parameters: {
     chromatic: { disableSnapshot: true },
+  },
+  args: {
+    messages: { placeholder: 'Change me' },
   },
 }
 

--- a/packages/shoreline/src/components/search/tests/search.test.tsx
+++ b/packages/shoreline/src/components/search/tests/search.test.tsx
@@ -8,7 +8,6 @@ import {
   render,
   fireEvent,
 } from '@vtex/shoreline-test-utils'
-import { LocaleProvider } from '../../locale'
 
 describe('search', () => {
   it('should render correctly', () => {
@@ -29,16 +28,6 @@ describe('search', () => {
     const { container } = render(<Search loading />)
 
     expect(container.querySelector('[data-sl-spinner]')).toBeInTheDocument()
-  })
-
-  it('should show have default placeholder localized', () => {
-    const { getByPlaceholderText } = render(<Search />, {
-      wrapper: ({ children }) => (
-        <LocaleProvider locale="pt-BR">{children}</LocaleProvider>
-      ),
-    })
-
-    expect(getByPlaceholderText('Pesquisar')).toBeInTheDocument()
   })
 
   it('should show have custom placeholder when placeholder prop is set', () => {

--- a/packages/shoreline/src/components/search/tests/search.test.tsx
+++ b/packages/shoreline/src/components/search/tests/search.test.tsx
@@ -8,6 +8,7 @@ import {
   render,
   fireEvent,
 } from '@vtex/shoreline-test-utils'
+import { LocaleProvider } from '../../locale'
 
 describe('search', () => {
   it('should render correctly', () => {
@@ -28,6 +29,16 @@ describe('search', () => {
     const { container } = render(<Search loading />)
 
     expect(container.querySelector('[data-sl-spinner]')).toBeInTheDocument()
+  })
+
+  it('should show have default placeholder localized', () => {
+    const { getByPlaceholderText } = render(<Search />, {
+      wrapper: ({ children }) => (
+        <LocaleProvider locale="pt-BR">{children}</LocaleProvider>
+      ),
+    })
+
+    expect(getByPlaceholderText('Pesquisar')).toBeInTheDocument()
   })
 
   it('should show have custom placeholder when placeholder prop is set', () => {

--- a/packages/shoreline/src/components/search/tests/search.test.tsx
+++ b/packages/shoreline/src/components/search/tests/search.test.tsx
@@ -31,7 +31,9 @@ describe('search', () => {
   })
 
   it('should show have custom placeholder when placeholder prop is set', () => {
-    const { getByPlaceholderText } = render(<Search placeholder="Buscar" />)
+    const { getByPlaceholderText } = render(
+      <Search messages={{ placeholder: 'Buscar' }} />
+    )
 
     expect(getByPlaceholderText('Buscar')).toBeInTheDocument()
   })


### PR DESCRIPTION
# Summary

Fix the **Search** component placeholder.
- [x] Default placeholder that is localized ("Search")
- [x] Still allow to pass a customized message (for example, "Search by name or ID")