### PR TITLE
chore: change to primitive color name

### DIFF
--- a/packages/docs/pages/foundations/index.mdx
+++ b/packages/docs/pages/foundations/index.mdx
@@ -6,7 +6,7 @@ Shoreline design tokens include Color, Typography, Spacing, Border, Radius, and 
 
 Reflects a product's style, creates hierarchy, and provides meaning to components and messages. [Learn more](https://shoreline.vtex.com/foundations/color) about colors rationale and best practices.
 
-### Base
+### Primitive
 
 <br />
 


### PR DESCRIPTION
## Summary

#1774 

 - Change `Base` heading on colors section to `Primitive`  

## Examples


