### PR TITLE
docs: fix typo in development-guideline

### DIFF
--- a/packages/docs/pages/guides/code/development-guideline.mdx
+++ b/packages/docs/pages/guides/code/development-guideline.mdx
@@ -141,7 +141,7 @@ Once your PR is approved, it will be merged to the main branch by a Shoreline ma
 
 </Steps>
 
-## How does our CI/CD works?
+## How does our CI/CD work?
 
 We use GitHub Actions to run our CI/CD. We have a robust workflow that runs every time a:
 


### PR DESCRIPTION
This was kind of a bad grammar mistake, the page will be a little bit nicer with it corrected.