### PR TITLE
fix: Crowdin file

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,2 @@
-# files:
-#   - source: /packages/admin-ui/src/search/messages/en.json
-#     translation: /%original_path%/%two_letters_code%.%file_extension%
+- source: /packages/shoreline/components/*/messages/en.json
+    translation: /%original_path%/%two_letters_code%.%file_extension%

--- a/packages/docs/pages/guides/code/component-model.mdx
+++ b/packages/docs/pages/guides/code/component-model.mdx
@@ -80,15 +80,5 @@ function Search(props) {
 }
 ```
 
-### Setup crowdin
-
-Add the messages folder path to the `crowndin.yml` configuration file located in the root of the project.
-
-```yml
-files:
-  - source: /packages/shoreline/src/components/YOUR_COMPONENT/messages/en.json
-    translation: /%original_path%/%two_letters_code%.%file_extension%
-```
-
 </Steps>
 


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->
Add a crowdin pattern to messages folder which eliminates the need for initial configuration, component by component

note: I've already used this configuration format, but since I can't test it locally, I think it's worth talking to someone in the localization (I think they might only be able to check after the merge)