### PR TITLE
feat(confirmation-modal): add critical prop

### DIFF
--- a/packages/shoreline/src/components/confirmation-modal/confirmation-modal.tsx
+++ b/packages/shoreline/src/components/confirmation-modal/confirmation-modal.tsx
@@ -50,6 +50,7 @@ export const ConfirmationModal = forwardRef<
     locale = 'en-US',
     messages,
     disabled = false,
+    critical = false,
     ...otherProps
   } = props
 
@@ -82,7 +83,7 @@ export const ConfirmationModal = forwardRef<
         <Button
           onClick={onConfirm}
           size="large"
-          variant="primary"
+          variant={critical ? 'critical' : 'primary'}
           aria-label={confirm}
           disabled={disabled}
         >
@@ -116,6 +117,11 @@ export interface ConfirmationModalOptions {
    * @default false
    */
   disabled?: boolean
+  /**
+   * Whether the confirm actions is critical.
+   * @default false
+   */
+  critical?: boolean
   /**
    * The BCP47 language code for the locale.
    * @link https://www.ietf.org/rfc/bcp/bcp47.txt


### PR DESCRIPTION
## Summary

Allow confirmation modals to be critical. 

## Examples

```jsx
<ConfirmationModal critical>
  <Text>Are you sure?</Text>
</ConfirmationModal>
```
