### PR TITLE
fix: add height property to input component

### DIFF
--- a/packages/shoreline/src/themes/sunrise/components/input.css
+++ b/packages/shoreline/src/themes/sunrise/components/input.css
@@ -53,6 +53,7 @@
     padding-left: var(--sl-space-4);
     padding-right: var(--sl-space-4);
     width: 100%;
+    height: 100%;
     border: none;
     background-color: unset;
     &:focus {


### PR DESCRIPTION
## Summary

Input does not have height padding, so the click does not work.

## Examples

![Screenshot 2024-08-19 at 14 57 42](https://github.com/user-attachments/assets/ca6dbbb9-447a-421a-8b12-8d22c976dbf5)

