### PR TITLE
fix: tag default variant

### DIFF
--- a/packages/shoreline/src/components/tag/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/tag/stories/show.stories.tsx
@@ -1,5 +1,5 @@
-import { Tag } from '../index'
 import { Stack } from '../../stack'
+import { Tag } from '../index'
 
 export default {
   title: 'components/tag',
@@ -11,16 +11,36 @@ export function Show() {
       <Tag>Default</Tag>
       Primary
       <Stack horizontal>
-        <Tag color="red">Red</Tag>
-        <Tag color="yellow">Yellow</Tag>
-        <Tag color="orange">Orange</Tag>
-        <Tag color="pink">Pink</Tag>
-        <Tag color="purple">Purple</Tag>
-        <Tag color="blue">Blue</Tag>
-        <Tag color="cyan">Cyan</Tag>
-        <Tag color="teal">Teal</Tag>
-        <Tag color="green">Green</Tag>
-        <Tag color="gray">Gray</Tag>
+        <Tag color="red" variant="primary">
+          Red
+        </Tag>
+        <Tag color="yellow" variant="primary">
+          Yellow
+        </Tag>
+        <Tag color="orange" variant="primary">
+          Orange
+        </Tag>
+        <Tag color="pink" variant="primary">
+          Pink
+        </Tag>
+        <Tag color="purple" variant="primary">
+          Purple
+        </Tag>
+        <Tag color="blue" variant="primary">
+          Blue
+        </Tag>
+        <Tag color="cyan" variant="primary">
+          Cyan
+        </Tag>
+        <Tag color="teal" variant="primary">
+          Teal
+        </Tag>
+        <Tag color="green" variant="primary">
+          Green
+        </Tag>
+        <Tag color="gray" variant="primary">
+          Gray
+        </Tag>
       </Stack>
       Secondary
       <Stack horizontal>

--- a/packages/shoreline/src/components/tag/tag.tsx
+++ b/packages/shoreline/src/components/tag/tag.tsx
@@ -10,7 +10,7 @@ import { forwardRef } from 'react'
 export const Tag = forwardRef<HTMLDivElement, TagProps>(
   function Tag(props, ref) {
     const {
-      variant = 'primary',
+      variant = 'secondary',
       size = 'normal',
       color = 'gray',
       children,


### PR DESCRIPTION
## Summary
Resolve https://github.com/vtex/shoreline/issues/1740

## Examples

```typescript
<Tag>Label</Tag> // renders secondary gray label
<Tag variant="primary">Label</Tag> // renders primary gray
```