### PR TITLE
fix(toast-stack): pass custom ariaProps to the Toast component

### DIFF
--- a/packages/shoreline/src/components/toast/toast-stack.tsx
+++ b/packages/shoreline/src/components/toast/toast-stack.tsx
@@ -53,6 +53,7 @@ export function ToastStack(props: ToastStackProps) {
               id={t.id}
               loading={t.type === 'loading'}
               variant={(t as any).variant as any}
+              ariaProps={toastOptions?.ariaProps || t.ariaProps}
             >
               {(t as any).message}
             </Toast>

--- a/packages/shoreline/src/components/toast/toast-stack.tsx
+++ b/packages/shoreline/src/components/toast/toast-stack.tsx
@@ -2,8 +2,8 @@ import type { CSSProperties } from 'react'
 import type { DefaultToastOptions } from 'react-hot-toast/headless'
 import { useToaster } from 'react-hot-toast/headless'
 
-import { ToastAppear } from './toast-appear'
 import { Toast } from './toast'
+import { ToastAppear } from './toast-appear'
 
 /**
  * Toasts can appear at any time to provide instant feedback on actions. They are usually temporary, but can also require the user to dismiss.
@@ -53,7 +53,8 @@ export function ToastStack(props: ToastStackProps) {
               id={t.id}
               loading={t.type === 'loading'}
               variant={(t as any).variant as any}
-              ariaProps={toastOptions?.ariaProps || t.ariaProps}
+              {...t.ariaProps}
+              {...toastOptions?.ariaProps}
             >
               {(t as any).message}
             </Toast>

--- a/packages/shoreline/src/components/toast/toast.tsx
+++ b/packages/shoreline/src/components/toast/toast.tsx
@@ -1,5 +1,6 @@
 import type { MouseEventHandler, ReactNode } from 'react'
 import { Children, isValidElement } from 'react'
+import type { ToastOptions } from 'react-hot-toast'
 import { toast as hotToast } from 'react-hot-toast/headless'
 import {
   IconCheckCircleFill,
@@ -23,12 +24,24 @@ import { Button } from '../button'
  * <Toast variant="success">Success!</Toast>
  */
 export function Toast(props: ToastProps) {
-  const { id, variant = 'informational', children, loading, onDismiss } = props
+  const {
+    id,
+    variant = 'informational',
+    children,
+    loading,
+    onDismiss,
+    ariaProps,
+  } = props
 
   const icon = loading ? <Spinner /> : getIcon(variant)
 
   return (
-    <div data-sl-toast data-loading={loading} data-variant={variant}>
+    <div
+      data-sl-toast
+      data-loading={loading}
+      data-variant={variant}
+      {...ariaProps}
+    >
       <div data-sl-toast-icon-container>{icon}</div>
       <div data-sl-toast-container>{renderChildren(children)}</div>
       <Bleed top="$space-2" end="$space-2" bottom="$space-2">
@@ -112,4 +125,5 @@ interface ToastProps {
    */
   duration?: number
   loading?: boolean
+  ariaProps: ToastOptions['ariaProps']
 }

--- a/packages/shoreline/src/components/toast/toast.tsx
+++ b/packages/shoreline/src/components/toast/toast.tsx
@@ -1,6 +1,9 @@
-import type { MouseEventHandler, ReactNode } from 'react'
+import type {
+  ComponentPropsWithoutRef,
+  MouseEventHandler,
+  ReactNode,
+} from 'react'
 import { Children, isValidElement } from 'react'
-import type { ToastOptions } from 'react-hot-toast'
 import { toast as hotToast } from 'react-hot-toast/headless'
 import {
   IconCheckCircleFill,
@@ -10,12 +13,12 @@ import {
   IconXCircleFill,
 } from '../../icons'
 
-import { Spinner } from '../spinner'
 import { Bleed } from '../bleed'
+import { Button } from '../button'
+import { IconButton } from '../icon-button'
+import { Spinner } from '../spinner'
 import { Text } from '../text'
 import type { ToastVariant } from './toast-types'
-import { IconButton } from '../icon-button'
-import { Button } from '../button'
 
 /**
  * Toasts can appear at any time to provide instant feedback on actions. They are usually temporary, but can also require the user to dismiss.
@@ -101,7 +104,7 @@ function getIcon(variant: ToastVariant = 'informational') {
   }
 }
 
-interface ToastProps {
+interface ToastProps extends ComponentPropsWithoutRef<'div'> {
   /**
    * Toast variant
    * @default 'informational'
@@ -125,5 +128,4 @@ interface ToastProps {
    */
   duration?: number
   loading?: boolean
-  ariaProps: ToastOptions['ariaProps']
 }

--- a/packages/shoreline/src/components/toast/toast.tsx
+++ b/packages/shoreline/src/components/toast/toast.tsx
@@ -30,7 +30,7 @@ export function Toast(props: ToastProps) {
     children,
     loading,
     onDismiss,
-    ariaProps,
+    ...restProps
   } = props
 
   const icon = loading ? <Spinner /> : getIcon(variant)
@@ -40,7 +40,7 @@ export function Toast(props: ToastProps) {
       data-sl-toast
       data-loading={loading}
       data-variant={variant}
-      {...ariaProps}
+      {...restProps}
     >
       <div data-sl-toast-icon-container>{icon}</div>
       <div data-sl-toast-container>{renderChildren(children)}</div>


### PR DESCRIPTION
## Summary

Resolves #1536 

## Examples

```typescript
// Renders the Toast component with role equal alert and aria-live equal assertive
<ToastStack toastOptions={
        {
          ariaProps: {
            role: 'alert',
            "aria-live": 'assertive'
          }
        }
      } />
```