### PR TITLE
docs: fix local build error

### DIFF
--- a/packages/docs/scripts/build-contributors.mjs
+++ b/packages/docs/scripts/build-contributors.mjs
@@ -294,6 +294,14 @@ function getIssuesOnFire(issues) {
 }
 
 async function main() {
+  if (!token) {
+    console.log('⚠️  Missing Github token')
+    console.log(
+      'To run this script locally you must create a .env file with the VTEX_GITHUB_BOT_TOKEN which gives access to the public_repo scope'
+    )
+    return
+  }
+
   const pulls = await fetchAllPullRequests()
   const issues = await fetchAllIssues()
 


### PR DESCRIPTION
## Summary

Related to #1859 

An error occurs every time you try to run the documentation build locally. This happens because we are generating some GitHub metrics for our [activity]() page that requires a GitHub token, when you don't have this set it breaks the documentation site. This PR fix it
