### PR TITLE
docs(fundations): change the order of colors 

### DIFF
--- a/packages/docs/pages/foundations/color.mdx
+++ b/packages/docs/pages/foundations/color.mdx
@@ -2,12 +2,6 @@
 
 Reflects a product's style, creates hierarchy, and provides meaning to components and messages.
 
-## Primitive
-
-<br />
-
-<TokensGrid foundation="color" />
-
 ## Background
 
 <br />
@@ -19,5 +13,11 @@ Reflects a product's style, creates hierarchy, and provides meaning to component
 <br />
 
 <TokensGrid foundation="fg" />
+
+## Primitive
+
+<br />
+
+<TokensGrid foundation="color" />
 
 Want to know more about design tokens? Read the [documentation](https://shoreline.vtex.com/guides/styling/design-tokens).

--- a/packages/docs/pages/foundations/index.mdx
+++ b/packages/docs/pages/foundations/index.mdx
@@ -6,11 +6,6 @@ Shoreline design tokens include Color, Typography, Spacing, Border, Radius, and 
 
 Reflects a product's style, creates hierarchy, and provides meaning to components and messages. [Learn more](https://shoreline.vtex.com/foundations/color) about colors rationale and best practices.
 
-### Base
-
-<br />
-
-<TokensGrid foundation="color" />
 
 ### Background
 
@@ -23,6 +18,12 @@ Reflects a product's style, creates hierarchy, and provides meaning to component
 <br />
 
 <TokensGrid foundation="fg" />
+
+### Primitive
+
+<br />
+
+<TokensGrid foundation="color" />
 
 ## Typography
 


### PR DESCRIPTION
fix #1764

## Summary

<!-- Explain the change motivation -->
Change colors order to prioritize semantics colors over primitives
Fix group of color title - from base to primitives

## Examples

<!-- Some code examples -->
![image](https://github.com/user-attachments/assets/db48f701-a6a5-4982-a2a8-4fa469d92808)

![image](https://github.com/user-attachments/assets/fdf924e4-5be5-40c5-8c2d-b6f1a07ab481)
