### PR TITLE
fix(page): change selector that changes button width to be more specific

### DIFF
--- a/packages/shoreline/src/components/page/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/page/stories/show.stories.tsx
@@ -14,6 +14,7 @@ import { Tag } from '../../tag'
 import { Stack } from '../../stack'
 import { IconArrowLeft } from '../../../icons'
 import { Flex } from '../../flex'
+import { Menu, MenuItem } from '../../menu'
 
 export default {
   title: 'components/page',
@@ -110,11 +111,19 @@ export function Show() {
               <PageHeading>Title</PageHeading>
               <Tag variant="secondary">Short text</Tag>
             </Flex>
-            <Bleed top="$space-2" bottom="$space-2">
-              <Button variant="primary" size="large">
-                Submit
-              </Button>
-            </Bleed>
+            <Stack space="$space-4" horizontal>
+              <Bleed top="$space-2" bottom="$space-2">
+                <Button variant="primary" size="large">
+                  Submit
+                </Button>
+              </Bleed>
+              <Bleed top="$space-2" bottom="$space-2">
+                <Menu label="Actions" type="actions" iconOnly size="large">
+                  <MenuItem>New Tab</MenuItem>
+                  <MenuItem>New Item</MenuItem>
+                </Menu>
+              </Bleed>
+            </Stack>
           </PageHeaderRow>
         </PageHeader>
         <PageContent layout="standard">

--- a/packages/shoreline/src/themes/sunrise/components/page.css
+++ b/packages/shoreline/src/themes/sunrise/components/page.css
@@ -11,7 +11,7 @@
 }
 
 [data-sl-page-header-container] {
-  :where(button) {
+  :where([data-sl-button]):not([data-sl-icon-button]) {
     min-width: 6.25rem;
   }
 


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->

The current selector increased the size for icon-only buttons, causing a style bug, so change the selector to be more specific

fix #1830

## Examples

<!-- Some code examples -->

Before
![image](https://github.com/user-attachments/assets/3ea056cf-535b-4b90-8cde-4ca667f6917a)

After
![image](https://github.com/user-attachments/assets/37b3c57e-6d5b-4529-bcbc-99c8378fe0f1)
