### PR TITLE
build(ts-table): fix the shoreline package peer dependency version

### DIFF
--- a/packages/ts-table/package.json
+++ b/packages/ts-table/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-table": ">=8",
-    "@vtex/shoreline": "0.x",
+    "@vtex/shoreline": ">= 1",
     "react": ">=18",
     "react-dom": ">=18"
   },

--- a/packages/ts-table/package.json
+++ b/packages/ts-table/package.json
@@ -37,7 +37,7 @@
   },
   "peerDependencies": {
     "@tanstack/react-table": ">=8",
-    "@vtex/shoreline": ">= 1",
+    "@vtex/shoreline": ">=1",
     "react": ">=18",
     "react-dom": ">=18"
   },


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->

Before the peer dependency to vtex/shoreline as fixed in the 1.x major, generating warnings when the user uses the latest versions of the packages. Now, the user can use `>=1`, withous warnings

fix #1826