### PR TITLE
docs(contributiong/code/component model): add information about internationalization

### DIFF
--- a/packages/docs/pages/guides/code/component-model.mdx
+++ b/packages/docs/pages/guides/code/component-model.mdx
@@ -82,10 +82,10 @@ function Search(props) {
 
 ### Provide overwriting capability
 
-In most cases, it is necessary to allow the user of the component to override the internal messages.
+Some cases require the user to override the internal messages.
 
-You do this by adding a property called `messages` and passing as argument to `useMessage`.
-The `messages` type must contain the same keys used in your files from `messages` folder.
+You do this by adding a property called `messages` and passing it as an argument to the `useMessage` hook.
+The `messages` type must contain the same keys defined in your files from the `messages` folder.
 
 ```tsx
 import { createMessageHook } from '@vtex/shoreline'

--- a/packages/docs/pages/guides/code/component-model.mdx
+++ b/packages/docs/pages/guides/code/component-model.mdx
@@ -60,7 +60,7 @@ Create a new folder `messages` under the component folder. This is where you wil
 ```json
 // messages/en.json file
 {
-  "admin/search-label": "Search"
+  "search-label": "Search"
 }
 ```
 
@@ -76,9 +76,44 @@ const useMessage = createMessageHook(messages)
 function Search(props) {
   const getMessage = useMessage()
 
-  return <input placeholder={getMessage('admin/search-label')} {...props}/>
+  return <input placeholder={getMessage('search-label')} {...props}/>
 }
 ```
+
+### Provide overwriting capability
+
+In most cases, it is necessary to allow the user of the component to override the internal messages.
+
+You do this by adding a property called `messages` and passing as argument to `useMessage`.
+The `messages` type must contain the same keys used in your files from `messages` folder.
+
+```tsx
+import { createMessageHook } from '@vtex/shoreline'
+
+const useMessage = createMessageHook(messages)
+
+function Search(props) {
+  const { messages } = props
+  const getMessage = useMessage(messages)
+
+  return <input placeholder={getMessage('search-label')} {...props}/>
+}
+
+interface SearchOptions {
+  /**
+   * Search internal messages
+   */
+  messages?: SearchMessages
+}
+
+export type SearchProps = SearchOptions & ComponentPropsWithoutRef<'input'>
+
+type SearchMessages = {
+  'search-label'?: string
+}
+
+```
+
 
 </Steps>
 


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->

Add info about the pattern that must be followed to enable override of component messages

fix #1777

## Examples

<!-- Some code examples -->
![image](https://github.com/user-attachments/assets/5296a069-528d-4f9e-ac0e-fa41e07fc7d2)
