### PR TITLE
fix(toast-function): pass dismiss method from lib

### DIFF
--- a/packages/shoreline/src/components/toast/stories/examples.stories.tsx
+++ b/packages/shoreline/src/components/toast/stories/examples.stories.tsx
@@ -1,6 +1,6 @@
-import { ToastStack, toast } from '../index'
-import { Stack } from '../../stack'
 import { Button } from '../../button'
+import { Stack } from '../../stack'
+import { ToastStack, toast } from '../index'
 
 export default {
   title: 'components/toast',
@@ -56,6 +56,21 @@ export function ToastFunction() {
         }}
       >
         Promise
+      </Button>
+      <Button
+        onClick={() => {
+          toast.dismiss()
+        }}
+      >
+        Cleanup all
+      </Button>
+      <Button
+        onClick={() => {
+          const id = toast.loading('Loading...')
+          setTimeout(() => toast.dismiss(id), 2000)
+        }}
+      >
+        Cleanup loading toast after 2 seconds!
       </Button>
     </Stack>
   )

--- a/packages/shoreline/src/components/toast/toast-function.ts
+++ b/packages/shoreline/src/components/toast/toast-function.ts
@@ -25,6 +25,7 @@ export const toast = {
   promise(promise: Promise<any>, messages: ToastPromiseMessages) {
     return toastFactory.promise(promise, messages)
   },
+  dismiss: toastFactory.dismiss,
 }
 
 function getOptions(variant: ToastVariant): any {


### PR DESCRIPTION
## Summary

Resolves #1605 

## Examples

```typescript
// To cleanup all toasts
<Button
  onClick={() => {
    toast.dismiss()
  }}
>
  Cleanup all
</Button>

// To cleanup specific toast
<Button
  onClick={() => {
    const id = toast.loading('Loading...')
    setTimeout(() => toast.dismiss(id), 2000)
  }}
>
  Cleanup loading toast after 2 seconds!
</Button>
```