### PR TITLE
fix(filter): setValue prop type

### DIFF
--- a/packages/shoreline/src/components/filter/filter-provider.tsx
+++ b/packages/shoreline/src/components/filter/filter-provider.tsx
@@ -38,7 +38,7 @@ export function FilterProvider<Value extends string | string[] = string>(
 
   const filterStore = useSelectStore({
     value,
-    setValue: setValue as any,
+    setValue,
     defaultValue,
   })
 

--- a/packages/shoreline/src/components/filter/filter-provider.tsx
+++ b/packages/shoreline/src/components/filter/filter-provider.tsx
@@ -1,10 +1,9 @@
-import type React from 'react'
+import type { Dispatch, ReactNode } from 'react'
 import { useEffect } from 'react'
-import type { ReactNode } from 'react'
 import { ComboboxProvider } from '../combobox'
 
-import { SelectProvider, useSelectStore } from '../select'
 import { PopoverProvider, usePopoverStore } from '../popover'
+import { SelectProvider, useSelectStore } from '../select'
 import { FilterContext } from './filter-context'
 
 /**
@@ -15,7 +14,9 @@ import { FilterContext } from './filter-context'
  *   <FilterPopover>...</FilterPopover>
  * </FilterProvider>
  */
-export function FilterProvider(props: FilterProviderProps) {
+export function FilterProvider<Value extends string | string[] = string>(
+  props: FilterProviderProps<Value>
+) {
   const {
     children,
     open,
@@ -77,7 +78,9 @@ export function FilterProvider(props: FilterProviderProps) {
   )
 }
 
-export interface FilterProviderOptions {
+export interface FilterProviderOptions<
+  Value extends string | string[] = string,
+> {
   /**
    * Children of FilterProvider
    */
@@ -109,17 +112,16 @@ export interface FilterProviderOptions {
   /**
    * Filter value
    */
-  value?: string | string[]
+  value?: Value
   /**
    * Callback to set the filter value
    */
-  setValue?:
-    | React.Dispatch<React.SetStateAction<string>>
-    | React.Dispatch<React.SetStateAction<string[]>>
+  setValue?: Dispatch<Value>
   /**
    * Filter default value
    */
-  defaultValue?: string | string[]
+  defaultValue?: Value
 }
 
-export type FilterProviderProps = FilterProviderOptions
+export type FilterProviderProps<Value extends string | string[] = string> =
+  FilterProviderOptions<Value>

--- a/packages/shoreline/src/components/filter/filter.tsx
+++ b/packages/shoreline/src/components/filter/filter.tsx
@@ -1,4 +1,4 @@
-import type { ComponentPropsWithoutRef } from 'react'
+import type { ComponentPropsWithoutRef, ForwardedRef } from 'react'
 import { forwardRef } from 'react'
 import { FilterList } from './filter-list'
 import type { FilterPopoverProps } from './filter-popover'
@@ -6,6 +6,43 @@ import { FilterPopover } from './filter-popover'
 import type { FilterProviderProps } from './filter-provider'
 import { FilterProvider } from './filter-provider'
 import { FilterTrigger, type FilterTriggerProps } from './filter-trigger'
+
+const FilterComp = <Value extends string | string[] = string>(
+  props: FilterProps<Value>,
+  ref: ForwardedRef<HTMLDivElement>
+) => {
+  const {
+    children,
+    label,
+    value,
+    setValue,
+    defaultValue,
+    searchValue,
+    setSearchValue,
+    defaultSearchValue,
+    messages,
+    disabled,
+    ...otherProps
+  } = props
+
+  return (
+    <div data-sl-filter ref={ref} {...otherProps}>
+      <FilterProvider
+        value={value}
+        setValue={setValue}
+        defaultValue={defaultValue}
+        searchValue={searchValue}
+        setSearchValue={setSearchValue}
+        defaultSearchValue={defaultSearchValue}
+      >
+        <FilterTrigger disabled={disabled}>{label}</FilterTrigger>
+        <FilterPopover messages={messages}>
+          <FilterList>{children}</FilterList>
+        </FilterPopover>
+      </FilterProvider>
+    </div>
+  )
+}
 
 /**
  * Filters represent criteria that users can choose to narrow down a Collection. They can include single or multiple selection.
@@ -15,44 +52,15 @@ import { FilterTrigger, type FilterTriggerProps } from './filter-trigger'
  *  <FilterItem value="option">Option</FilterItem>
  * </Filter>
  */
-export const Filter = forwardRef<HTMLDivElement, FilterProps>(
-  function Filter(props, ref) {
-    const {
-      children,
-      label,
-      value,
-      setValue,
-      defaultValue,
-      searchValue,
-      setSearchValue,
-      defaultSearchValue,
-      messages,
-      disabled,
-      ...otherProps
-    } = props
+export const Filter = forwardRef(FilterComp) as <
+  Value extends string | string[] = string,
+>(
+  props: FilterProps<Value>,
+  ref: ForwardedRef<HTMLDivElement>
+) => JSX.Element
 
-    return (
-      <div data-sl-filter ref={ref} {...otherProps}>
-        <FilterProvider
-          value={value}
-          setValue={setValue}
-          defaultValue={defaultValue}
-          searchValue={searchValue}
-          setSearchValue={setSearchValue}
-          defaultSearchValue={defaultSearchValue}
-        >
-          <FilterTrigger disabled={disabled}>{label}</FilterTrigger>
-          <FilterPopover messages={messages}>
-            <FilterList>{children}</FilterList>
-          </FilterPopover>
-        </FilterProvider>
-      </div>
-    )
-  }
-)
-
-type InheritedOptions = Pick<
-  FilterProviderProps,
+type InheritedOptions<Value extends string | string[] = string> = Pick<
+  FilterProviderProps<Value>,
   | 'value'
   | 'setValue'
   | 'defaultValue'
@@ -63,11 +71,13 @@ type InheritedOptions = Pick<
   Pick<FilterPopoverProps, 'messages'> &
   Pick<FilterTriggerProps, 'disabled'>
 
-export interface FilterOptions extends InheritedOptions {
+export interface FilterOptions<Value extends string | string[] = string>
+  extends InheritedOptions<Value> {
   /**
    * Filter label
    */
   label: string
 }
 
-export type FilterProps = FilterOptions & ComponentPropsWithoutRef<'div'>
+export type FilterProps<Value extends string | string[] = string> =
+  FilterOptions<Value> & ComponentPropsWithoutRef<'div'>


### PR DESCRIPTION
## Summary

Resolves #1504 

## Examples

We have made a significant improvement in terms of consistency for those using the component. The types can be assumed based on props if you are using a multi- or single-value filter. So, if you pass a callback using an array of strings, it infers the value prop and the default value with the same type. Besides that, it is now possible to use custom handles on the setValue prop.

```typescript
type Props = {
  onFilterChange: (value: string[]) => void
  filterValue: string[]
  defaultFilterValue: string[]
}

const MyFilter = (props: Props) => {
  const { onFilterChange, defaultFilterValue, filterValue } = props

  return (
    <Filter
        value={filterValue} // Based on setValue prop it infers the string[] type here
        setValue={onFilterChange} // No more type errors here
        label="Multiple status"
        defaultValue={defaultFilterValue} // Based on setValue prop it infers the string[] type here
      >
      <FilterItem value="Stable">Stable</FilterItem>
      <FilterItem value="Experimental">Experimental</FilterItem>
      <FilterItem value="Deprecated">Deprecated</FilterItem>
    </Filter>
  )
}
```