### PR TITLE
fix(create-message-hook): dynamic values is not a isolated word

### DIFF
--- a/packages/shoreline/src/components/locale/create-message-hook.ts
+++ b/packages/shoreline/src/components/locale/create-message-hook.ts
@@ -58,18 +58,12 @@ function get(
 
   if (!variables) return localizedMessage
 
-  const dynamicMessage = localizedMessage
-    .split(' ')
-    .map((word) => {
-      const isDynamicWord = word.startsWith('{') && word.endsWith('}')
-
-      if (!isDynamicWord) return word
-
-      const dynamicValue = word.slice(1, -1)
-
-      return variables[dynamicValue] ?? word
-    })
-    .join(' ')
+  const dynamicMessage = Object.entries(variables).reduce(
+    (acc, [key, value]) => {
+      return acc.replace(new RegExp(`{${key}}`, 'g'), String(value))
+    },
+    localizedMessage
+  )
 
   return dynamicMessage
 }

--- a/packages/shoreline/src/components/locale/tests/create-message-hook.test.tsx
+++ b/packages/shoreline/src/components/locale/tests/create-message-hook.test.tsx
@@ -134,4 +134,28 @@ describe('create-message-hook', () => {
 
     expect(getByText('4 of {pages}')).toBeInTheDocument()
   })
+
+  it("gets dynamic message when isn't a isolated word", () => {
+    const messages = {
+      'en-US': {
+        selectAll: 'Select all ({n})',
+      },
+    }
+
+    const useMessage = createMessageHook(messages)
+
+    const hook = renderHook(() => useMessage(), {
+      wrapper: ({ children }) => (
+        <LocaleProvider locale="en-US">{children}</LocaleProvider>
+      ),
+    })
+
+    const { getByText } = render(
+      <LocaleProvider locale="en-US">
+        <div>{hook.result.current('selectAll', { n: 142 })}</div>
+      </LocaleProvider>
+    )
+
+    expect(getByText('Select all (142)')).toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->

Change the way to replace the dinamyc values to not be necessary that it is rounded by empty spaces

fix #1896

## Examples

<!-- Some code examples -->
It is possible to see an example that was used to test the feature in the test file
