### PR TITLE
refactor(text): add export to TextOptions interface

### DIFF
--- a/packages/shoreline/src/components/index.ts
+++ b/packages/shoreline/src/components/index.ts
@@ -243,7 +243,7 @@ export type {
 export { Tag } from './tag'
 export type { TagProps } from './tag'
 export { Text } from './text'
-export type { TextProps } from './text'
+export type { TextProps, TextOptions } from './text'
 export { Textarea } from './textarea'
 export type { TextareaProps } from './textarea'
 export { ToastStack, toast } from './toast'


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->
For the same reasons related in #1852, the other components has the props ans options interfaces exported, but Text component hasn't. This dificult make extensions to be used in the apps

## Examples

<!-- Some code examples -->
