### PR TITLE
feat(text): add `color` prop support

### DIFF
--- a/packages/shoreline/src/components/text/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/text/stories/show.stories.tsx
@@ -17,6 +17,9 @@ export function Show() {
       <Text variant="display3">Display 3</Text>
       <Text variant="display4">Display 4</Text>
       <Text variant="emphasis">Emphasis</Text>
+      <Text variant="body" color="#FF0000">
+        Custom Color
+      </Text>
     </Stack>
   )
 }

--- a/packages/shoreline/src/components/text/text.tsx
+++ b/packages/shoreline/src/components/text/text.tsx
@@ -1,14 +1,20 @@
-import type { AnyObject } from '@vtex/shoreline-utils'
+import { type AnyObject, style } from '@vtex/shoreline-utils'
 import type { ComponentPropsWithoutRef } from 'react'
 import { forwardRef } from 'react'
 
 /**
  * Text component
  * @example
- * <Text variant="context">Hello world</Text>
+ * <Text variant="context" color="#000000">Hello world</Text>
  */
 export const Text = forwardRef(function Text(props: TextProps, ref: any) {
-  const { children, variant = 'context', ...otherProps } = props
+  const {
+    children,
+    variant = 'context',
+    color = 'var(--sl-fg-base)',
+    style: styleObject = {},
+    ...otherProps
+  } = props
 
   const Element = props.as || 'span'
 
@@ -17,6 +23,10 @@ export const Text = forwardRef(function Text(props: TextProps, ref: any) {
       data-sl-text
       ref={ref}
       data-variant={variant}
+      style={style({
+        '--sl-text-color': color,
+        ...styleObject,
+      })}
       {...(otherProps as AnyObject)}
     >
       {children}
@@ -25,6 +35,12 @@ export const Text = forwardRef(function Text(props: TextProps, ref: any) {
 })
 
 export interface TextOptions {
+  /**
+   * Text color
+   * @default var(--sl-fg-base)
+   */
+  color?: string
+
   /**
    * Text variant
    * @default 'context'

--- a/packages/shoreline/src/components/text/text.tsx
+++ b/packages/shoreline/src/components/text/text.tsx
@@ -40,7 +40,6 @@ export interface TextOptions {
    * @default var(--sl-fg-base)
    */
   color?: string
-
   /**
    * Text variant
    * @default 'context'

--- a/packages/shoreline/src/themes/sunrise/components/text.css
+++ b/packages/shoreline/src/themes/sunrise/components/text.css
@@ -1,6 +1,9 @@
 [data-sl-text] {
+  --sl-text-color: var(--sl-fg-base);
+
   overflow-wrap: break-word;
   text-wrap: pretty;
+  color: var(--sl-text-color);
 
   &[data-variant='body'] {
     font: var(--sl-text-body-font);


### PR DESCRIPTION
## Summary

Adds support for the `color` prop to the `Text` component. It closes https://github.com/vtex/shoreline/issues/1855.

## Examples


### Text with color
```tsx

function ErrorText({ text }) {
  return <Text variant="body" color="#FF0000">{text}</Text>
}

```

### Text with color from a CSS Variable
```tsx

function StatusText({ text }) {
  return <Text variant="body" color="var(--status-text)">{text}</Text>
}

```
