### PR TITLE
fix(table): backgroup color change in hover and selection update

### DIFF
--- a/packages/shoreline/src/themes/sunrise/components/table.css
+++ b/packages/shoreline/src/themes/sunrise/components/table.css
@@ -86,7 +86,7 @@
   }
 }
 
-[data-sl-table-row] [data-selected='true'] {
+[data-sl-table-row][data-selected='true'] {
   [data-sl-table-cell] {
     background: var(--sl-bg-accent);
   }
@@ -138,7 +138,7 @@
   }
 }
 
-[data-sl-table-row] [data-dim-on-hover='true']:hover {
+[data-sl-table-row][data-dim-on-hover='true']:hover {
   &[data-selected='false'] {
     [data-sl-table-cell] {
       background: var(--sl-bg-base-soft);


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->
Change backgroup color when row is in hover and when the row is selected (fix commit 5f331186c958)

fix #1926
Fix erro from lint:css in pr #1928