### PR TITLE
fix(text): change default color to inherit

### DIFF
--- a/packages/shoreline/src/components/text/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/text/stories/show.stories.tsx
@@ -20,6 +20,9 @@ export function Show() {
       <Text variant="body" color="#FF0000">
         Custom Color
       </Text>
+      <div style={{ color: 'var(--sl-fg-base-soft)' }}>
+        <Text>Custom color from parent</Text>
+      </div>
     </Stack>
   )
 }

--- a/packages/shoreline/src/components/text/text.tsx
+++ b/packages/shoreline/src/components/text/text.tsx
@@ -11,7 +11,7 @@ export const Text = forwardRef(function Text(props: TextProps, ref: any) {
   const {
     children,
     variant = 'context',
-    color = 'var(--sl-fg-base)',
+    color = 'inherit',
     style: styleObject = {},
     ...otherProps
   } = props
@@ -37,7 +37,7 @@ export const Text = forwardRef(function Text(props: TextProps, ref: any) {
 export interface TextOptions {
   /**
    * Text color
-   * @default var(--sl-fg-base)
+   * @default inherit
    */
   color?: string
   /**


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->

changes the default color so that the text maintains the default behavior of a span

fix #1931

## Examples

<!-- Some code examples -->
The story changed
