### PR TITLE
(docs): Include icon synonyms

### DIFF
--- a/packages/docs/components/icons-grid/icons.ts
+++ b/packages/docs/components/icons-grid/icons.ts
@@ -111,11 +111,11 @@ const iconsInfo = [
   },
   {
     name: 'ChartBar',
-    description: 'graph; performance; metrics; data; stats; report',
+    description: 'graph; performance; metrics; data; stats; report; dashboard',
   },
   {
     name: 'ChartLineUp',
-    description: 'graph; performance; metrics; data; stats; report; growth',
+    description: 'graph; performance; metrics; data; stats; report; dashboard; growth',
   },
   {
     name: 'ChatText',


### PR DESCRIPTION
As the title says. Redoing #1828 because of conflicts.