### PR TITLE
Update toast timing in best practices

### DIFF
--- a/packages/docs/pages/components/toast/best-practices.mdx
+++ b/packages/docs/pages/components/toast/best-practices.mdx
@@ -48,4 +48,4 @@ Toasts are always dismissible. For non-dismissible notifications, read the Alert
 ### Timing
 
 - **Trigger:** Toasts appear immediately after an action is triggered (user presses *Save*) or the loading feedback is over (Button stops spinning).
-- **Duration:** Most Toasts should last between 5 and 10 seconds, following an average of 3.5 milliseconds per character. Use a permanent toast only when they require attention, such as critical Toasts, warning Toasts, and any Toast that is not the immediate result of an user action.
+- **Duration:** Most Toasts should last between 5 and 10 seconds, following an average of 175 milliseconds per character. Use a permanent toast only when they require attention, such as critical Toasts, warning Toasts, and any Toast that is not the immediate result of an user action.


### PR DESCRIPTION
As the title says. Redoing #1915 because of conflicts.