### PR TITLE
fix(contextual-help): change to use IconButton instance of Button

### DIFF
--- a/packages/shoreline/src/components/contextual-help/contextual-help.tsx
+++ b/packages/shoreline/src/components/contextual-help/contextual-help.tsx
@@ -2,7 +2,7 @@ import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import { forwardRef } from 'react'
 import type { PopoverProviderProps } from '../popover'
 import { PopoverProvider, PopoverTrigger, Popover } from '../popover'
-import { Button } from '../button'
+import { IconButton } from '../icon-button'
 import { Container, Content } from '../content'
 
 /**
@@ -38,9 +38,9 @@ export const ContextualHelp = forwardRef<HTMLDivElement, ContextualHelpProps>(
           placement={placement}
         >
           <PopoverTrigger asChild>
-            <Button data-sl-contextual-help-trigger aria-label={label}>
+            <IconButton data-sl-contextual-help-trigger label={label}>
               <div data-sl-contextual-help-trigger-bg>?</div>
-            </Button>
+            </IconButton>
           </PopoverTrigger>
           <Popover
             data-sl-contextual-help-popover


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->

It is necessary change from Button to IconButton to fix the min width, that needs be as icon button (auto) and not regular button (min width with fixed size)

fix #1967


## Examples

<!-- Some code examples -->
Before:
<img width="716" alt="image" src="https://github.com/user-attachments/assets/33ff2fb4-60b1-4322-aa34-6446d8b2c041">

After:
<img width="670" alt="image" src="https://github.com/user-attachments/assets/d903dd6d-a022-42a9-98a7-b740cde6705c">
