### PR TITLE
fix(contextual-help): change z-index of popover

### DIFF
--- a/packages/shoreline/src/themes/sunrise/components/contextual-help.css
+++ b/packages/shoreline/src/themes/sunrise/components/contextual-help.css
@@ -36,6 +36,7 @@
   --sl-contextual-help-popover-max-height: 27.5rem;
   --sl-contextual-help-popover-width: 21.375rem;
 
+  z-index: var(--sl-z-10);
   min-height: var(--sl-contextual-help-popover-min-height);
   max-height: var(--sl-contextual-help-popover-max-height);
   width: var(--sl-contextual-help-popover-width);


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->
It is necessary that z-index of popover is largest than modal z-index to be visible hel contextual help is inside the modal (modal is opened)

fix #1970
