### PR TITLE
docs(filter): add Filter with Combobox page

### DIFF
--- a/packages/docs/pages/components/filter/filter-with-combobox.mdx
+++ b/packages/docs/pages/components/filter/filter-with-combobox.mdx
@@ -1,0 +1,3 @@
+# Filter with Combobox
+
+Filter component with a search input. Demo on the [storybook page](https://shoreline.storybook.vtex.com/?path=/story/components-filter--with-combobox).


### PR DESCRIPTION
There was no link to the Storybook example of a Filter with Combobox component

## Summary

Add sub page of the Filter documentation. 

## Examples


<img width="1530" alt="Screenshot 2024-09-26 at 13 24 46" src="https://github.com/user-attachments/assets/f7856543-3f52-4da0-a13c-5df6b9a9a1a4">
