### PR TITLE
fix(toast): add font style to data-sl-toast

### DIFF
--- a/packages/shoreline/src/themes/sunrise/components/toast.css
+++ b/packages/shoreline/src/themes/sunrise/components/toast.css
@@ -5,6 +5,7 @@
   align-items: flex-start;
   gap: var(--sl-space-0) var(--sl-space-3);
   color: var(--sl-fg-base);
+  font: var(--sl-text-emphasis-font);
   padding: var(--sl-space-4) var(--sl-space-5);
   width: 22.5rem;
   border-radius: var(--sl-radius-2);


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->
This is necessary to ensure that the font setting is applied correctly regardless of where the toast stack is instantiated

fix #1978