### PR TITLE
fix(filter-value): show children text content instead of value

### DIFF
--- a/packages/shoreline/src/components/filter/filter-value.tsx
+++ b/packages/shoreline/src/components/filter/filter-value.tsx
@@ -1,5 +1,6 @@
+import { useSelectContext } from '@ariakit/react'
 import type { ComponentPropsWithoutRef } from 'react'
-import { forwardRef } from 'react'
+import { forwardRef, useCallback } from 'react'
 import { useFilterContext } from './filter-context'
 
 const valueSeparator = ': '
@@ -13,14 +14,25 @@ export const FilterValue = forwardRef<HTMLSpanElement, FilterValueProps>(
     const filter = useFilterContext()
     const value = filter?.useState('value')
 
-    const isArray = Array.isArray(value)
-    const isLongArray = isArray && value.length > 1
+    const valueIsArray = Array.isArray(value)
+    const valueIsMultiSelected = valueIsArray && value.length > 1
+
+    const selectContext = useSelectContext()
+    const items = selectContext?.useState('items')
+
+    const getValueText = useCallback(
+      () =>
+        items?.find((item) =>
+          valueIsArray ? item.value === value[0] : item.value === value
+        )?.element?.innerText,
+      [value, valueIsArray, items]
+    )
 
     return (
       <span data-sl-filter-value ref={ref} {...props}>
         {value && value.length > 0 && valueSeparator}
-        {isArray ? value[0] : value}
-        {isLongArray && `${countPrefix}${value.length - 1}`}
+        {getValueText()}
+        {valueIsMultiSelected && `${countPrefix}${value.length - 1}`}
       </span>
     )
   }

--- a/packages/shoreline/src/components/filter/stories/examples.stories.tsx
+++ b/packages/shoreline/src/components/filter/stories/examples.stories.tsx
@@ -1,20 +1,20 @@
-import { useState, useMemo, startTransition } from 'react'
 import { matchSorter } from 'match-sorter'
+import { startTransition, useMemo, useState } from 'react'
 
+import { EmptyState, Heading, Text } from '../..'
+import { IconMagnifyingGlass } from '../../../icons'
+import { EmptyStateIllustration } from '../../empty-state'
+import { LocaleProvider } from '../../locale'
 import {
-  FilterProvider,
-  FilterPopover,
-  FilterList,
-  FilterItem,
-  FilterTrigger,
   Filter,
+  FilterItem,
+  FilterList,
+  FilterPopover,
+  FilterProvider,
+  FilterTrigger,
 } from '../index'
 import type { Country } from './countries'
 import { countries } from './countries'
-import { LocaleProvider } from '../../locale'
-import { IconMagnifyingGlass } from '../../../icons'
-import { EmptyState, Text, Heading } from '../..'
-import { EmptyStateIllustration } from '../../empty-state'
 
 export default {
   title: 'components/filter',
@@ -31,6 +31,18 @@ export function Controlled() {
       <FilterItem value="Stable">Stable</FilterItem>
       <FilterItem value="Experimental">Experimental</FilterItem>
       <FilterItem value="Deprecated">Deprecated</FilterItem>
+    </Filter>
+  )
+}
+
+export function CustomLabel() {
+  const [city, setCity] = useState<string>('')
+
+  return (
+    <Filter label="Cidade" value={city} setValue={setCity}>
+      <FilterItem value="rj">Rio de Janeiro</FilterItem>
+      <FilterItem value="sp">São Paulo</FilterItem>
+      <FilterItem value="mg">Minas Gerais</FilterItem>
     </Filter>
   )
 }


### PR DESCRIPTION
## Summary
Partially resolves #1505 

Now, the **inner text** from the children of the selected item is used on the selected value. Pay attention to the inner text expression here because it is not precisely the children property. So, no HTML tags will be rendered. I see that as a quick solution to not change all the state logic created.

## Examples

### Simple
For this example, when the item with value `rj` is selected, the filter will show 'Cidade: Rio de Janeiro'

```typescript
const [city, setCity] = useState<string>('')

<Filter label="Cidade" value={city} setValue={setCity}>
  <FilterItem value="rj">Rio de Janeiro</FilterItem>
  <FilterItem value="sp">São Paulo</FilterItem>
  <FilterItem value="mg">Minas Gerais</FilterItem>
 </Filter>
```

### Multiple
For this example, when the items with values `rj` and `mg` are selected in that order, the filter will show 'Cidade: Rio de Janeiro, +1'

```typescript
const [cities, setCities] = useState<string>([])

<Filter label="Cidade" value={cities} setValue={setCities}>
  <FilterItem value="rj">Rio de Janeiro</FilterItem>
  <FilterItem value="sp">São Paulo</FilterItem>
  <FilterItem value="mg">Minas Gerais</FilterItem>
 </Filter>
```
