### PR TITLE
fix(1980): add portal option to DatePicker, MenuPopover, and Popover components

### DIFF
--- a/packages/shoreline/src/components/date-picker/date-picker.tsx
+++ b/packages/shoreline/src/components/date-picker/date-picker.tsx
@@ -22,7 +22,13 @@ import { useStore } from '@vtex/shoreline-utils'
  * <DatePicker />
  */
 export function DatePicker<T extends DateValue>(props: DatePickerProps<T>) {
-  const { className, id: defaultId, error: defaultError, ...domProps } = props
+  const {
+    className,
+    id: defaultId,
+    error: defaultError,
+    portal = true,
+    ...domProps
+  } = props
   const state = useDatePickerState(domProps)
   const ref = useRef(null)
   const anchorRef = useRef<HTMLDivElement>(null)
@@ -68,6 +74,7 @@ export function DatePicker<T extends DateValue>(props: DatePickerProps<T>) {
         </div>
       </div>
       <Popover
+        portal={portal}
         getAnchorRect={() => {
           if (anchorRef?.current) {
             return anchorRef.current.getBoundingClientRect()
@@ -92,6 +99,11 @@ export interface DatePickerOptions<T extends DateValue>
    * Wether has error
    */
   error?: boolean
+  /**
+   * Should activate portal
+   * @default true
+   */
+  portal?: boolean
 }
 
 export type DatePickerProps<T extends DateValue> = DatePickerOptions<T>

--- a/packages/shoreline/src/components/menu/menu-popover.tsx
+++ b/packages/shoreline/src/components/menu/menu-popover.tsx
@@ -8,7 +8,7 @@ import { Menu } from '@ariakit/react'
  */
 export const MenuPopover = forwardRef<HTMLDivElement, MenuPopoverProps>(
   function MenuPopover(props, ref) {
-    const { children, asChild = false, ...otherProps } = props
+    const { children, asChild = false, portal = true, ...otherProps } = props
 
     return (
       <Menu
@@ -16,7 +16,7 @@ export const MenuPopover = forwardRef<HTMLDivElement, MenuPopoverProps>(
         ref={ref}
         render={asChild && (children as any)}
         gutter={4}
-        portal
+        portal={portal}
         {...otherProps}
       >
         {children}
@@ -31,6 +31,11 @@ export interface MenuPopoverOptions {
    * @default false
    */
   asChild?: boolean
+  /**
+   * Should activate portal
+   * @default true
+   */
+  portal?: boolean
 }
 
 export type MenuPopoverProps = MenuPopoverOptions &

--- a/packages/shoreline/src/components/popover/popover.tsx
+++ b/packages/shoreline/src/components/popover/popover.tsx
@@ -15,14 +15,14 @@ import { Popover as BasePopover } from '@ariakit/react'
  */
 export const Popover = forwardRef<HTMLDivElement, PopoverProps>(
   function Popover(props, ref) {
-    const { children, asChild = false, ...otherProps } = props
+    const { children, asChild = false, portal = true, ...otherProps } = props
 
     return (
       <BasePopover
         data-sl-popover
         ref={ref}
         render={asChild && (children as any)}
-        portal
+        portal={portal}
         gutter={4}
         {...otherProps}
       >
@@ -38,6 +38,11 @@ export interface PopoverOptions extends Pick<BaseProps, 'getAnchorRect'> {
    * @default false
    */
   asChild?: boolean
+  /**
+   * Should activate portal
+   * @default true
+   */
+  portal?: boolean
 }
 
 export type PopoverProps = PopoverOptions & ComponentPropsWithoutRef<'div'>


### PR DESCRIPTION
## Summary

Currently we have this problem: [1980](https://github.com/vtex/shoreline/issues/1980).
To fix it, it's necessary to disable portal prop when using Menu and DataPicker, according to discussion at [this thread](https://vtex.slack.com/archives/C01DVTFA4VA/p1727380818432499).
To make this possible, it's necessary to add portal prop to DatePicker, MenuPopover and Popover components, so it's possible to define portal as `false` when using MenuPopover or DataPicker.

## Examples

Before
```javascript
<Menu label="Open menu">
  <MenuItem>Item 1</MenuItem>
  <MenuItem>Item 2</MenuItem>
</Menu>
```

#### Result

https://github.com/user-attachments/assets/7f333af3-7d65-4917-bc9a-85f98623adf0


### After

```javascript
<MenuProvider>
  <MenuTrigger asChild>
    <Button>Open menu</Button>
  </MenuTrigger>
  <MenuPopover portal={false}>
    <MenuItem>Item 1</MenuItem>
    <MenuItem>Item 2</MenuItem>
  </MenuPopover>
</MenuProvider>
```

#### Result

https://github.com/user-attachments/assets/0bf3edb2-9a3f-49dd-9dab-e48ca44fa6c7




