### PR TITLE
fix(input): pass disabled to native input

### DIFF
--- a/packages/shoreline/src/components/input/input.tsx
+++ b/packages/shoreline/src/components/input/input.tsx
@@ -58,6 +58,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             _setValue(e.target.value)
           }
           id={id}
+          disabled={disabled}
           {...otherProps}
         />
         {suffix && (


### PR DESCRIPTION
## Summary

The disabled prop is not being passed to the native input element, is only applying the disabled style

## Examples

<!-- Some code examples -->

[Codesandbox](https://codesandbox.io/p/sandbox/2jxclc)