### PR TITLE
docs: fix how to contribute

### DIFF
--- a/packages/docs/pages/guides/how-to-contribute.mdx
+++ b/packages/docs/pages/guides/how-to-contribute.mdx
@@ -119,38 +119,6 @@ When the issue is in great shape and includes the necessary information and/or f
 
 </Steps>
 
-## Idea
-
-Submitting an idea means that you just want to suggest an enhancement to Shoreline.
-
-![Idea flow](/assets/idea.png)
-
-<Steps>
-
-### Open an issue
-
-Use the [idea](https://github.com/vtex/shoreline/issues/new/choose) template and answer questions about the feature
-like what is the context, how can we benefit from it, and the rationale behind it.
-If you already have a potential solution to this issue don’t forget to share it.
-Don't worry if you aren’t sure about the issue! Share it and start a discussion as early
-as possible.
-
-### Discussion
-
-You can get feedback through comments on the GitHub issue or by attending office hours. Make sure to share
-all the necessary information about the feature so the community can help giving
-insights and sharing their context as well. As you make progress, make sure to
-update your issue.
-
-### Definition
-
-As the discussions and refinements occur, your issue can be classified as valid to
-be resolved or not.
-
-If the issue is classified as valid by a maintainer and needs a design or code proposal, it will be tagged as `design wanted` or `dev wanted` and a volunteer will be responsible for starting a [proposal flow](https://shoreline.vtex.com/guides/processes#submit-a-proposal).
-
-</Steps>
-
 ## Question & Feedback
 
 Asking a question or sending a feedback means that you have something to share with


### PR DESCRIPTION
Removes the `Idea` issue type from the `How to contribute` documentation.