### PR TITLE
fix(calendar-grid): change key used in week days mapping

### DIFF
--- a/packages/shoreline/src/components/calendar/calendar-grid.tsx
+++ b/packages/shoreline/src/components/calendar/calendar-grid.tsx
@@ -24,8 +24,8 @@ export function CalendarGrid(props: CalendarGridProps) {
     <table data-sl-calendar-grid {...gridProps}>
       <thead data-sl-calendar-grid-header {...headerProps}>
         <tr>
-          {weekDays.map((day) => (
-            <th key={day}>{day}</th>
+          {weekDays.map((day, index) => (
+            <th key={`${day}=${index}`}>{day}</th>
           ))}
         </tr>
       </thead>


### PR DESCRIPTION
## Summary

<!-- Explain the change motivation -->
change the key used to be the week day character plus the index to avoid warnings when diferents days have the semana character for identification

fix #2041
