### PR TITLE
docs: updates `best-practices.mdx`'s broken link

### DIFF
--- a/packages/docs/pages/foundations/icons/best-practices.mdx
+++ b/packages/docs/pages/foundations/icons/best-practices.mdx
@@ -28,4 +28,4 @@ In Shoreline, they are identified by the prefix `Icon` and their naming conventi
 
 ## New icons
 
-If there's no icon already in Shoreline that fits your needs, follow the [contribution guidelines](https://shoreline.vtex.com/guides/processes) to request or propose one. As mentioned in the [rationale](https://shoreline.vtex.com/foundations/icons/rationale), custom-designed icons are strongly discouraged to avoid inconsistency, but if there are no options in the Phosphor library we can start a discussion.
+If there's no icon already in Shoreline that fits your needs, follow the [contribution guidelines](https://shoreline.vtex.com/guides/how-to-contribute) to request or propose one. As mentioned in the [rationale](https://shoreline.vtex.com/foundations/icons/rationale), custom-designed icons are strongly discouraged to avoid inconsistency, but if there are no options in the Phosphor library we can start a discussion.


### PR DESCRIPTION
## Summary
`Contribution guidelines` links was getting a 404 error, I've changed it to the correct url.
