### PR TITLE
fix(select): add missing className to select div

### DIFF
--- a/packages/shoreline/src/components/select/select.tsx
+++ b/packages/shoreline/src/components/select/select.tsx
@@ -66,7 +66,7 @@ export const Select = forwardRef<HTMLButtonElement, SelectProps>(
     const id = defaultId || contextId
 
     return (
-      <div data-sl-select>
+      <div data-sl-select className={className}>
         <SelectProvider store={select}>
           <SelectTrigger
             data-sl-select-button


### PR DESCRIPTION
## Summary

The Select component accepts a `className` prop and even destructures it internally, however it never applies it to any element.
This adds `className` to the `data-sl-select` div.

## Examples
Select ignores className:
https://codesandbox.io/p/sandbox/eloquent-chatelet-kkvrpg