### PR TITLE
chore: update release GH worflow upload-artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
-          registry-url: 'https://registry.npmjs.org'
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Configure CI Git User
         run: bash ./scripts/configure-git-user.sh
@@ -43,7 +43,7 @@ jobs:
         run: pnpm build
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |


### PR DESCRIPTION
## Summary

As per the [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) states from Github:

>Starting January 30th, 2025, GitHub Actions customers will no longer be able to use v3 of [actions/upload-artifact](https://github.com/actions/upload-artifact) or [actions/download-artifact](https://github.com/actions/download-artifact)

Since SL currently uses V3, all releases merged to main won't fulfill starting today. That said, we must update the artifact to V4 asap.

## Examples

[Sophia's run failing](https://github.com/vtex/shoreline/actions/runs/13059615071)
