### PR TITLE
fix(tag): change tag height to fit its content

### DIFF
--- a/packages/shoreline/src/components/page/stories/play.stories.tsx
+++ b/packages/shoreline/src/components/page/stories/play.stories.tsx
@@ -82,7 +82,7 @@ export function Play(args: StoryArgs) {
       <TabProvider defaultSelectedId="selected">
         <PageHeader>
           <PageHeaderRow>
-            <Flex>
+            <Flex align="center">
               {args.headerWithBackButton && (
                 <Bleed top="$space-2" bottom="$space-2">
                   <IconButton

--- a/packages/shoreline/src/components/page/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/page/stories/show.stories.tsx
@@ -47,7 +47,7 @@ export function Show() {
         <TabProvider>
           <PageHeader>
             <PageHeaderRow>
-              <Flex>
+              <Flex align="center">
                 <Bleed top="$space-2" bottom="$space-2">
                   <IconButton
                     label="Return"
@@ -97,7 +97,7 @@ export function Show() {
       <Page>
         <PageHeader>
           <PageHeaderRow>
-            <Flex>
+            <Flex align="center">
               <Bleed top="$space-2" bottom="$space-2">
                 <IconButton
                   label="Return"
@@ -133,7 +133,7 @@ export function Show() {
       <Page>
         <PageHeader>
           <PageHeaderRow>
-            <Flex>
+            <Flex align="center">
               <Bleed top="$space-2" bottom="$space-2">
                 <IconButton
                   label="Return"
@@ -161,7 +161,7 @@ export function Show() {
       <Page>
         <PageHeader>
           <PageHeaderRow>
-            <Flex>
+            <Flex align="center">
               <Bleed top="$space-2" bottom="$space-2">
                 <IconButton
                   label="Return"

--- a/packages/shoreline/src/themes/sunrise/components/tag.css
+++ b/packages/shoreline/src/themes/sunrise/components/tag.css
@@ -1,6 +1,7 @@
 [data-sl-tag] {
   --sl-border-radius-largest: calc(var(--sl-radius-3) * 2);
 
+  height: fit-content;
   width: fit-content;
   padding: var(--sl-element-space-top) var(--sl-element-space-right)
     var(--sl-element-space-bottom) var(--sl-element-space-left);


### PR DESCRIPTION
## Summary

When rendering a Tag within the PageHeaderRow its height was increasing which caused a misalignment on its content. This PR Fix it.

## Examples

<!-- Some code examples -->
**Before**
<img width="252" alt="Screenshot 2025-04-02 at 11 44 20" src="https://github.com/user-attachments/assets/930025bb-a1e6-4b9a-abb0-b1fc97c3eefd" />

**After**
<img width="261" alt="Screenshot 2025-04-02 at 11 44 32" src="https://github.com/user-attachments/assets/6f905428-e8da-4bda-8a80-24e8ec347ce6" />
