### PR TITLE
chore(storybook): makes main.js follow Common JS syntax, which allows it to be run with node-23.8

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
-import { dirname, join } from 'node:path'
+const { dirname, join } = require('node:path')
 
 module.exports = {
   stories: ['../packages/**/*.stories.@(js|jsx|ts|tsx)'],


### PR DESCRIPTION
Main.js mixed Common JS and ESM syntax, which prevented `pnpm dev:storybook` from working in (at least) node 23.7 and 23.8.

[Storybook breaks in newer versions of Node.js #2083](https://github.com/vtex/shoreline/issues/2083)

## Summary
This file caused some headaches after i formatted my computer and installed the latest version of node, which was supposed to work with shoreline, only to find that storybook randomly wouldn't run anymore.
<!-- Explain the change motivation -->

## Example
```js
// .storybook/main.s
import { dirname, join } from 'node:path'
// turns into
const { dirname, join } = require('node:path')
```


