### PR TITLE
fix(select): add missing exports from the global index

### DIFF
--- a/packages/shoreline/src/components/index.ts
+++ b/packages/shoreline/src/components/index.ts
@@ -211,6 +211,8 @@ export {
   SelectTrigger,
   useSelectContext,
   useSelectStore,
+  SelectArrow,
+  SelectValue,
 } from './select'
 export type {
   SelectProps,


### PR DESCRIPTION
## Summary

As the title says

## Examples

<!-- Some code examples -->
