### PR TITLE
fix: Bug in Nested Stacks

### DIFF
--- a/packages/shoreline/src/components/stack/stories/depth.stories.tsx
+++ b/packages/shoreline/src/components/stack/stories/depth.stories.tsx
@@ -1,0 +1,60 @@
+import { Stack } from '../index'
+import { style } from '@vtex/shoreline-utils'
+
+export default {
+  title: 'components/stack',
+}
+
+const itemStyle = style({
+  background: '$color-blue-3',
+  borderRadius: '$border-radius-2',
+  width: '5rem',
+  height: '3rem',
+  display: 'grid',
+  placeItems: 'center',
+})
+
+export function Depth() {
+  return (
+    <div className="App">
+      <p style={{ margin: '0 0 var(--sl-space-2)' }}>With two coluns:</p>
+      <Stack space="$space-10" horizontal>
+        <Stack space="$space-1">
+          <div style={itemStyle}>Col A 1</div>
+          <div style={itemStyle}>Col A 2</div>
+          <div style={itemStyle}>Col A 3</div>
+        </Stack>
+
+        <Stack space="$space-1">
+          <div style={itemStyle}>Col B 1</div>
+          <div style={itemStyle}>Col B 2</div>
+          <div style={itemStyle}>Col B 3</div>
+        </Stack>
+      </Stack>
+
+      <p style={{ margin: 'var(--sl-space-10) 0 var(--sl-space-2)' }}>
+        With three coluns:
+      </p>
+
+      <Stack space="$space-20" horizontal>
+        <Stack space="$space-10">
+          <div style={itemStyle}>Col A 1</div>
+          <div style={itemStyle}>Col A 2</div>
+          <div style={itemStyle}>Col A 3</div>
+        </Stack>
+
+        <Stack space="$space-5">
+          <div style={itemStyle}>Col B 1</div>
+          <div style={itemStyle}>Col B 2</div>
+          <div style={itemStyle}>Col B 3</div>
+        </Stack>
+
+        <Stack space="$space-1">
+          <div style={itemStyle}>Col C 1</div>
+          <div style={itemStyle}>Col C 2</div>
+          <div style={itemStyle}>Col C 3</div>
+        </Stack>
+      </Stack>
+    </div>
+  )
+}

--- a/packages/shoreline/src/themes/sunrise/components/stack.css
+++ b/packages/shoreline/src/themes/sunrise/components/stack.css
@@ -8,13 +8,10 @@
     flex-direction: column;
     justify-content: flex-start;
     align-items: var(--sl-stack-align);
+    row-gap: var(--sl-stack-space);
 
     & > * {
       margin-block: 0;
-    }
-
-    & > * + * {
-      margin-block-start: var(--sl-stack-space);
     }
 
     &[data-fluid="true"] {
@@ -27,13 +24,10 @@
     flex-direction: row;
     align-items: center;
     justify-content: var(--sl-stack-align);
+    column-gap: var(--sl-stack-space);
 
     & > * {
       margin-inline: 0;
-    }
-
-    & > * + * {
-      margin-inline-start: var(--sl-stack-space);
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix https://github.com/vtex/shoreline/issues/1684

## Examples

A story was added with the following code:

```
export function Depth() {
  return (
    <div className="App">
      <p style={{ margin: '0 0 var(--sl-space-2)' }}>With two coluns:</p>
      <Stack space="$space-10" horizontal>
        <Stack space="$space-1">
          <div style={itemStyle}>Col A 1</div>
          <div style={itemStyle}>Col A 2</div>
          <div style={itemStyle}>Col A 3</div>
        </Stack>

        <Stack space="$space-1">
          <div style={itemStyle}>Col B 1</div>
          <div style={itemStyle}>Col B 2</div>
          <div style={itemStyle}>Col B 3</div>
        </Stack>
      </Stack>

      <p style={{ margin: 'var(--sl-space-10) 0 var(--sl-space-2)' }}>
        With three coluns:
      </p>

      <Stack space="$space-20" horizontal>
        <Stack space="$space-10">
          <div style={itemStyle}>Col A 1</div>
          <div style={itemStyle}>Col A 2</div>
          <div style={itemStyle}>Col A 3</div>
        </Stack>

        <Stack space="$space-5">
          <div style={itemStyle}>Col B 1</div>
          <div style={itemStyle}>Col B 2</div>
          <div style={itemStyle}>Col B 3</div>
        </Stack>

        <Stack space="$space-1">
          <div style={itemStyle}>Col C 1</div>
          <div style={itemStyle}>Col C 2</div>
          <div style={itemStyle}>Col C 3</div>
        </Stack>
      </Stack>
    </div>
  )
}
```

Rendered result:
![Screenshot 2025-05-12 at 14 51 03](https://github.com/user-attachments/assets/3352072b-c9f3-4b76-bcb8-ceeee80bc367)

