### PR TITLE
fix: prevent button text from wrapping and icon to change size on small screens

### DIFF
--- a/packages/shoreline/src/themes/sunrise/components/button.css
+++ b/packages/shoreline/src/themes/sunrise/components/button.css
@@ -29,6 +29,14 @@
     transition: opacity 300ms;
     white-space: nowrap;
 
+    & [data-sl-icon] {
+      flex-shrink: 0;
+    }
+
+    & [data-sl-icon-small] {
+      flex-shrink: 0;
+    }
+
     & [data-sl-icon]:first-child {
       margin-left: calc(var(--sl-space-1) * -1);
     }


### PR DESCRIPTION
## 🐛 Bug Fix

### Problema
Os botões estavam quebrando o texto em múltiplas linhas em telas menores, causando problemas de layout na topbar.

### Solução
Adicionei `white-space: nowrap` ao conteúdo do botão para evitar que o texto quebre em múltiplas linhas.

### Mudanças
- Adicionado `white-space: nowrap` em `[data-sl-button-content]`
- Mantém o `min-width` original de `6.25rem`

### Resultado
✅ Texto do botão permanece em uma única linha
✅ Botões mantêm tamanho adequado
✅ Layout da topbar não quebra mais