### PR TITLE
Codebase bug resolution

### DIFF
--- a/packages/shoreline/src/components/filter/filter-provider.tsx
+++ b/packages/shoreline/src/components/filter/filter-provider.tsx
@@ -45,9 +45,12 @@ export function FilterProvider(props: FilterProviderProps) {
     defaultValue,
   })
 
-  useEffect(function syncState() {
-    selectStore.setValue(filterStore.getState().value)
-  }, [])
+  useEffect(
+    function syncState() {
+      selectStore.setValue(filterStore.getState().value)
+    },
+    [selectStore, filterStore]
+  )
 
   const searchable = !!searchValue || !!setSearchValue || !!defaultSearchValue
 

--- a/packages/shoreline/src/components/pagination/pagination.tsx
+++ b/packages/shoreline/src/components/pagination/pagination.tsx
@@ -41,7 +41,7 @@ export const Pagination = forwardRef<HTMLDivElement, PaginationProps>(
       const lastPosition = Math.min(page * size, total)
 
       return { firstPosition, lastPosition }
-    }, [page, total])
+    }, [page, total, size])
 
     const isSinglePage = total <= size
     const paginationLabel = isSinglePage

--- a/packages/utils/src/flatten-object.ts
+++ b/packages/utils/src/flatten-object.ts
@@ -8,7 +8,11 @@ export function flattenObject<T extends AnyObject>(
   const result: Dict = {}
 
   for (const i in object) {
-    if (typeof object[i] === 'object' && !Array.isArray(object[i])) {
+    if (
+      typeof object[i] === 'object' &&
+      object[i] !== null &&
+      !Array.isArray(object[i])
+    ) {
       const temp = flattenObject(object[i], joinString, defaultString)
 
       for (const j in temp) {

--- a/packages/utils/src/tests/flatten-object.test.ts
+++ b/packages/utils/src/tests/flatten-object.test.ts
@@ -20,6 +20,22 @@ describe('flattenObject', () => {
     expect(result).toStrictEqual(expectation)
   })
 
+  it('should preserve null values', () => {
+    const result = flattenObject({
+      a: {
+        b: null,
+        c: 'value',
+      },
+    })
+
+    const expectation = {
+      'a-b': null,
+      'a-c': 'value',
+    }
+
+    expect(result).toStrictEqual(expectation)
+  })
+
   it('should handle default values', () => {
     const result = flattenObject({
       a: {


### PR DESCRIPTION
## Summary

This PR addresses three bugs across the codebase:

1.  **Pagination `useMemo` Missing Dependency:** The `useMemo` hook in the Pagination component calculating `firstPosition` and `lastPosition` was missing `size` from its dependency array, leading to incorrect pagination labels when `size` changed.
2.  **Filter Provider `useEffect` Missing Dependencies:** The `useEffect` hook in `FilterProvider` had an empty dependency array, preventing proper synchronization between `selectStore` and `filterStore` if they changed after initial mount.
3.  **`flattenObject` Drops Null Values:** The `flattenObject` utility incorrectly dropped `null` values due to `typeof null === 'object'`, causing data loss when flattening objects containing `null`.

## Examples

**Bug 1: Pagination `useMemo` Missing Dependency**

```diff
--- a/packages/shoreline/src/components/pagination/pagination.tsx
+++ b/packages/shoreline/src/components/pagination/pagination.tsx
@@ -41,7 +41,7 @@ export const Pagination = forwardRef<HTMLDivElement, PaginationProps>(
       const lastPosition = Math.min(page * size, total)
 
       return { firstPosition, lastPosition }
-    }, [page, total])
+    }, [page, total, size])
 
     const isSinglePage = total <= size
     const paginationLabel = isSinglePage
```

**Bug 2: Filter Provider `useEffect` Missing Dependencies**

```diff
--- a/packages/shoreline/src/components/filter/filter-provider.tsx
+++ b/packages/shoreline/src/components/filter/filter-provider.tsx
@@ -45,9 +45,12 @@ export function FilterProvider(props: FilterProviderProps) {
     defaultValue,
   })
 
-  useEffect(function syncState() {
-    selectStore.setValue(filterStore.getState().value)
-  }, [])
+  useEffect(
+    function syncState() {
+      selectStore.setValue(filterStore.getState().value)
+    },
+    [selectStore, filterStore]
+  )
 
   const searchable = !!searchValue || !!setSearchValue || !!defaultSearchValue
```

**Bug 3: `flattenObject` Drops Null Values**

```diff
--- a/packages/utils/src/flatten-object.ts
+++ b/packages/utils/src/flatten-object.ts
@@ -8,7 +8,11 @@ export function flattenObject<T extends AnyObject>(
   const result: Dict = {}
 
   for (const i in object) {
-    if (typeof object[i] === 'object' && !Array.isArray(object[i])) {
+    if (
+      typeof object[i] === 'object' &&
+      object[i] !== null &&
+      !Array.isArray(object[i])
+    ) {
       const temp = flattenObject(object[i], joinString, defaultString)
 
       for (const j in temp) {
```

A new test case was added for `flattenObject` to ensure null values are preserved:

```typescript
  it('should preserve null values', () => {
    const result = flattenObject({
      a: {
        b: null,
        c: 'value',
      },
    })

    const expectation = {
      'a-b': null,
      'a-c': 'value',
    }

    expect(result).toStrictEqual(expectation)
  })
```

---
<a href="https://cursor.com/background-agent?bcId=bc-a7655c08-6209-4312-8734-f3aaa0e17546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7655c08-6209-4312-8734-f3aaa0e17546"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

