### PR TITLE
feat: add rounded corners option and update stories

### DIFF
--- a/packages/shoreline/src/components/button/button.tsx
+++ b/packages/shoreline/src/components/button/button.tsx
@@ -21,6 +21,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       loading = false,
       asChild = false,
       disabled = false,
+      rounded = false,
       children,
       ...buttonProps
     } = props
@@ -35,6 +36,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         data-variant={variant}
         data-size={size}
         data-loading={loading}
+        data-rounded={rounded}
         type={type}
         disabled={disabled || loading}
         {...buttonProps}
@@ -96,6 +98,11 @@ export interface ButtonOptions {
    * @default false
    */
   asChild?: boolean
+  /**
+   * Render button with fully rounded corners (pill shape).
+   * @default false
+   */
+  rounded?: boolean
 }
 
 export type ButtonProps = ButtonOptions & ComponentPropsWithoutRef<'button'>

--- a/packages/shoreline/src/components/button/stories/play.stories.tsx
+++ b/packages/shoreline/src/components/button/stories/play.stories.tsx
@@ -27,6 +27,10 @@ export default {
       control: { type: 'boolean' },
       description: 'Disable the button and show a spinner.',
     },
+    rounded: {
+      control: { type: 'boolean' },
+      description: 'Render button with fully rounded corners.',
+    },
     children: {
       control: { type: 'text' },
       description: 'Content of the contextual help',
@@ -36,6 +40,7 @@ export default {
     size: 'normal',
     variant: 'secondary',
     loading: false,
+    rounded: false,
     children: 'Shoreline',
   },
   parameters: {

--- a/packages/shoreline/src/components/button/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/button/stories/show.stories.tsx
@@ -20,34 +20,34 @@ export function Show() {
     'criticalTertiary',
   ]
 
-  const getGrid = (size: 'normal' | 'large') => (
+  const getGrid = (size: 'normal' | 'large', rounded = false) => (
     <div className="variants--grid">
       {variants.map((variant) => (
         <Fragment key={variant}>
           <div className="variants--grid-leading">{variant}</div>
           <div>
-            <Button size={size} variant={variant}>
+            <Button size={size} variant={variant} rounded={rounded}>
               Default
             </Button>
           </div>
           <div>
-            <Button size={size} variant={variant} loading>
+            <Button size={size} variant={variant} rounded={rounded} loading>
               Loading
             </Button>
           </div>
           <div>
-            <Button size={size} variant={variant} disabled>
+            <Button size={size} variant={variant} rounded={rounded} disabled>
               Disabled
             </Button>
           </div>
           <div>
-            <Button size={size} variant={variant}>
+            <Button size={size} variant={variant} rounded={rounded}>
               <IconTrash />
               Icon
             </Button>
           </div>
           <div>
-            <Button size={size} variant={variant}>
+            <Button size={size} variant={variant} rounded={rounded}>
               Icon
               <IconArrowUpRightSmall />
             </Button>
@@ -59,8 +59,14 @@ export function Show() {
 
   return (
     <div>
+      <h3>Normal</h3>
       {getGrid('normal')}
+      <h3>Large</h3>
       {getGrid('large')}
+      <h3>Rounded Normal</h3>
+      {getGrid('normal', true)}
+      <h3>Rounded Large</h3>
+      {getGrid('large', true)}
     </div>
   )
 }

--- a/packages/shoreline/src/components/button/stories/tests/rounded.stories.tsx
+++ b/packages/shoreline/src/components/button/stories/tests/rounded.stories.tsx
@@ -1,0 +1,21 @@
+import { within, expect } from '@storybook/test'
+
+import { Button } from '../../index'
+
+export default {
+  title: 'components/button/tests',
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+}
+
+export function Rounded() {
+  return <Button rounded>Rounded Button</Button>
+}
+
+Rounded.play = async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+  const canvas = within(canvasElement)
+  const button = canvas.getByRole('button')
+
+  await expect(button).toHaveAttribute('data-rounded', 'true')
+}

--- a/packages/shoreline/src/components/icon-button/stories/show.stories.tsx
+++ b/packages/shoreline/src/components/icon-button/stories/show.stories.tsx
@@ -35,25 +35,52 @@ export function Show() {
   const permutations = generatePermutations()
 
   return (
-    <Grid columns={`repeat(${variants.length}, 1fr)`}>
-      {permutations.map((permutation) => {
-        return (
-          <GridCell key={`${permutation.size}-${permutation.variant}`}>
-            <IconButton
-              label="Delete"
-              size={permutation.size}
-              variant={permutation.variant}
+    <div>
+      <h3>Default</h3>
+      <Grid columns={`repeat(${variants.length}, 1fr)`}>
+        {permutations.map((permutation) => {
+          return (
+            <GridCell key={`${permutation.size}-${permutation.variant}`}>
+              <IconButton
+                label="Delete"
+                size={permutation.size}
+                variant={permutation.variant}
+              >
+                <IconTrash />
+              </IconButton>
+            </GridCell>
+          )
+        })}
+        <GridCell>
+          <IconButton label="Delete" onClick={() => null} loading>
+            <IconTrash />
+          </IconButton>
+        </GridCell>
+      </Grid>
+      <h3>Rounded</h3>
+      <Grid columns={`repeat(${variants.length}, 1fr)`}>
+        {permutations.map((permutation) => {
+          return (
+            <GridCell
+              key={`rounded-${permutation.size}-${permutation.variant}`}
             >
-              <IconTrash />
-            </IconButton>
-          </GridCell>
-        )
-      })}
-      <GridCell>
-        <IconButton label="Delete" onClick={() => null} loading>
-          <IconTrash />
-        </IconButton>
-      </GridCell>
-    </Grid>
+              <IconButton
+                label="Delete"
+                size={permutation.size}
+                variant={permutation.variant}
+                rounded
+              >
+                <IconTrash />
+              </IconButton>
+            </GridCell>
+          )
+        })}
+        <GridCell>
+          <IconButton label="Delete" onClick={() => null} loading rounded>
+            <IconTrash />
+          </IconButton>
+        </GridCell>
+      </Grid>
+    </div>
   )
 }

--- a/packages/shoreline/src/themes/sunrise/components/button.css
+++ b/packages/shoreline/src/themes/sunrise/components/button.css
@@ -192,4 +192,8 @@
       }
     }
   }
+
+  &[data-rounded="true"] {
+    border-radius: var(--sl-radius-full);
+  }
 }


### PR DESCRIPTION
- Introduced a `rounded` prop to the Button component for fully rounded corners.
- Updated button stories to include examples of rounded buttons.
- Added a new test story for verifying the rounded button functionality.
- Enhanced CSS to apply border-radius for rounded buttons.

## Summary

Add the prop to make button and icon-button rounded

## Examples

<img width="653" height="280" alt="image" src="https://github.com/user-attachments/assets/5ede1f77-83c7-4482-a8b2-30b133160d5d" />
