### PR TITLE
docs(toast): document toast functions API

### DIFF
--- a/packages/docs/pages/components/toast.mdx
+++ b/packages/docs/pages/components/toast.mdx
@@ -12,3 +12,27 @@
 ### Watch promises
 
 <Preview name="toast-promise" />
+
+## Functions
+
+The `toast` object exposes the following methods to dispatch toasts imperatively. Each method accepts a `message` argument of type `string | JSX.Element` and returns a toast `id`.
+
+| Method | Description |
+| --- | --- |
+| `toast.informational(message)` | Dispatches an informational toast |
+| `toast.success(message)` | Dispatches a success toast |
+| `toast.critical(message)` | Dispatches a critical toast |
+| `toast.warning(message)` | Dispatches a warning toast |
+| `toast.loading(message)` | Dispatches a loading toast with a spinner |
+| `toast.promise(promise, messages)` | Tracks a promise and dispatches loading, success, or error toasts accordingly. The `messages` argument is an object with `loading`, `success`, and `error` keys, each accepting `string \| JSX.Element` |
+| `toast.dismiss(toastId?)` | Dismisses a toast by id, or all toasts if no id is provided |
+
+> **Note:** A [`ToastStack`](/components/toast/toast-stack) must be rendered in your application for toasts to appear.
+
+## Related components
+
+<ComponentSummaryGrid>
+  <ComponentSummary name="toast-stack" />
+  <ComponentSummary name="alert" />
+  <ComponentSummary name="modal" />
+</ComponentSummaryGrid>

--- a/packages/shoreline/src/components/toast/toast-function.ts
+++ b/packages/shoreline/src/components/toast/toast-function.ts
@@ -7,24 +7,31 @@ import type { ToastVariant } from './toast-types'
  * toast.informational('Message!')
  */
 export const toast = {
+  /** Dispatches an informational toast */
   informational(message: ToastMessage) {
     return toastFactory(message, getOptions('informational'))
   },
+  /** Dispatches a success toast */
   success(message: ToastMessage) {
     return toastFactory.success(message, getOptions('success'))
   },
+  /** Dispatches a critical toast */
   critical(message: ToastMessage) {
     return toastFactory.error(message, getOptions('critical'))
   },
+  /** Dispatches a warning toast */
   warning(message: ToastMessage) {
     return toastFactory(message, getOptions('warning'))
   },
+  /** Dispatches a loading toast with a spinner */
   loading(message: ToastMessage) {
     return toastFactory.loading(message, getOptions('informational'))
   },
+  /** Tracks a promise and dispatches loading, success, or error toasts accordingly */
   promise(promise: Promise<any>, messages: ToastPromiseMessages) {
     return toastFactory.promise(promise, messages)
   },
+  /** Dismisses a toast by id, or all toasts if no id is provided */
   dismiss: toastFactory.dismiss,
 }
 


### PR DESCRIPTION
## Summary

- Adds a **Functions** section to the Toast documentation page (`toast.mdx`) with a table describing all `toast` methods: `informational`, `success`, `critical`, `warning`, `loading`, `promise`, and `dismiss`, along with their signatures and descriptions.
- Adds JSDoc comments to each method in `toast-function.ts` for IDE intellisense.
- Adds **Related components** section linking to ToastStack, Alert, and Modal.

Closes #1812

## Test plan

- [x] Verify the Toast docs page renders the new Functions table correctly
- [x] Verify the Related components section renders with proper links
- [x] Confirm `toast` method JSDoc comments appear in IDE hover/autocomplete

Made with [Cursor](https://cursor.com)