### PR TITLE
fix(docs): correct DecorativeBox import paths in variant examples

### DIFF
--- a/packages/docs/examples/variants/README.md
+++ b/packages/docs/examples/variants/README.md
@@ -9,8 +9,13 @@ variants/
 ├── alert_variants.tsx
 ├── button_variants.tsx
 ├── checkbox_variants.tsx
+├── checkboxgroup_variants.tsx
+├── collection_variants.tsx
 ├── collectionview_variants.tsx
+├── confirmationmodal_variants.tsx
+├── contextualhelp_variants.tsx
 ├── datepicker_variants.tsx
+├── daterangepicker_variants.tsx
 ├── divider_variants.tsx
 ├── drawer_variants.tsx
 ├── emptystate_variants.tsx
@@ -20,10 +25,15 @@ variants/
 ├── link_variants.tsx
 ├── menu_variants.tsx
 ├── modal_variants.tsx
+├── page_variants.tsx
 ├── pagination_variants.tsx
+├── radiogroup_variants.tsx
 ├── search_variants.tsx
 ├── select_variants.tsx
 ├── skeleton_variants.tsx
+├── spinner_variants.tsx
+├── tablist_variants.tsx
+├── table_variants.tsx
 ├── tag_variants.tsx
 ├── text_variants.tsx
 ├── textarea_variants.tsx
@@ -62,6 +72,18 @@ Each file contains multiple named exports, one for each variant or state of the 
 - `CheckedDisabledCheckbox` - Checked and disabled checkbox
 - `IndeterminateDisabledCheckbox` - Indeterminate and disabled checkbox
 
+### CheckboxGroup Variants (`checkboxgroup_variants.tsx`)
+- `DefaultCheckboxGroup` - Basic vertical checkbox group
+- `HorizontalCheckboxGroup` - Horizontal layout
+- `CheckboxGroupWithError` - Error state with errorText
+- `CheckboxGroupWithDescription` - With description text
+- `HorizontalCheckboxGroupWithError` - Horizontal layout with error
+
+### Collection Variants (`collection_variants.tsx`)
+- `DefaultCollection` - Collection with Search and Pagination
+- `CollectionWithContent` - Collection with content in CollectionView
+- `CollectionWithAlignedRow` - CollectionRow with different align values
+
 ### CollectionView Variants (`collectionview_variants.tsx`)
 - `LoadingCollectionView` - Loading status
 - `ReadyCollectionView` - Ready status with items
@@ -70,10 +92,30 @@ Each file contains multiple named exports, one for each variant or state of the 
 - `NotFoundCollectionView` - Not found status
 - `UnauthorizedCollectionView` - Unauthorized status
 
+### ConfirmationModal Variants (`confirmationmodal_variants.tsx`)
+- `DefaultConfirmationModal` - Basic confirmation modal
+- `ConfirmationModalWithCustomText` - Modal with custom confirmation text
+
+### ContextualHelp Variants (`contextualhelp_variants.tsx`)
+- `DefaultContextualHelp` - Default contextual help
+- `ContextualHelpTopStart` - Placement top-start
+- `ContextualHelpBottomStart` - Placement bottom-start
+- `ContextualHelpTopEnd` - Placement top-end
+- `ContextualHelpBottomEnd` - Placement bottom-end
+
 ### DatePicker Variants (`datepicker_variants.tsx`)
 - `DefaultDatePicker` - Default date picker
 - `DisabledDatePicker` - Disabled date picker
 - `ReadOnlyDatePicker` - Read-only date picker
+- `DatePickerWithError` - Date picker with error state
+- `DatePickerControlled` - Controlled date picker with state
+
+### DateRangePicker Variants (`daterangepicker_variants.tsx`)
+- `DefaultDateRangePicker` - Default date range picker
+- `DisabledDateRangePicker` - Disabled state
+- `ReadOnlyDateRangePicker` - Read-only state
+- `DateRangePickerWithError` - Date range picker with error state
+- `DateRangePickerControlled` - Controlled date range picker with state
 
 ### Divider Variants (`divider_variants.tsx`)
 - `HorizontalDivider` - Horizontal orientation
@@ -84,9 +126,15 @@ Each file contains multiple named exports, one for each variant or state of the 
 - `MediumDrawer` - Medium drawer size
 
 ### EmptyState Variants (`emptystate_variants.tsx`)
+**Size prop:**
 - `SmallEmptyState` - Small empty state size
 - `MediumEmptyState` - Medium empty state size
 - `LargeEmptyState` - Large empty state size
+
+**With illustration and actions:**
+- `EmptyStateWithIllustration` - Empty state with icon illustration
+- `EmptyStateWithActions` - Empty state with action buttons
+- `EmptyStateComplete` - Complete empty state with illustration, heading, text and actions
 
 ### Heading Variants (`heading_variants.tsx`)
 - `Display1Heading` - Display1 heading variant
@@ -125,11 +173,24 @@ Each file contains multiple named exports, one for each variant or state of the 
 - `MediumModal` - Medium modal size
 - `LargeModal` - Large modal size
 
+### Page Variants (`page_variants.tsx`)
+- `DefaultPage` - Basic page with header and content
+- `PageWithButton` - Page with action button in header
+- `PageNarrow` - Page with narrow layout
+- `PageWide` - Page with wide layout
+
 ### Pagination Variants (`pagination_variants.tsx`)
 - `DefaultPagination` - Default pagination
 - `LoadingPagination` - Loading state pagination
 - `SmallPageSizePagination` - Pagination with small page size (10)
 - `LargePageSizePagination` - Pagination with large page size (50)
+
+### RadioGroup Variants (`radiogroup_variants.tsx`)
+- `DefaultRadioGroup` - Basic vertical radio group
+- `HorizontalRadioGroup` - Horizontal layout
+- `RadioGroupWithError` - Error state with errorText
+- `RadioGroupWithDescription` - With description text
+- `HorizontalRadioGroupWithError` - Horizontal layout with error
 
 ### Search Variants (`search_variants.tsx`)
 - `DefaultSearch` - Default search
@@ -144,6 +205,20 @@ Each file contains multiple named exports, one for each variant or state of the 
 ### Skeleton Variants (`skeleton_variants.tsx`)
 - `CircleSkeleton` - Circle shape
 - `RectSkeleton` - Rectangle shape
+
+### Spinner Variants (`spinner_variants.tsx`)
+- `DefaultSpinner` - Default spinner with description
+- `SpinnerWithCustomDescription` - Spinner with custom description text
+
+### TabList Variants (`tablist_variants.tsx`)
+- `DefaultTabList` - Basic tab list with panels
+- `TabListWithThreeTabs` - Tab list with three tabs
+- `TabListWithMultiplePanels` - Extended example with different content
+
+### Table Variants (`table_variants.tsx`)
+- `DefaultTable` - Basic table with data
+- `TableWithTags` - Table with tag components
+- `TableWithCustomWidths` - Table with custom column widths
 
 ### Tag Variants (`tag_variants.tsx`)
 **Variant prop:**
@@ -214,15 +289,26 @@ Import the specific variant you need:
 import { PrimaryButton, LargeSizeButton } from './variants/button_variants'
 import { SuccessAlert } from './variants/alert_variants'
 import { DefaultCheckbox, IndeterminateCheckbox } from './variants/checkbox_variants'
+import { DefaultCheckboxGroup, HorizontalCheckboxGroup } from './variants/checkboxgroup_variants'
+import { DefaultCollection, CollectionWithContent } from './variants/collection_variants'
+import { DefaultConfirmationModal } from './variants/confirmationmodal_variants'
+import { DefaultContextualHelp, ContextualHelpBottomStart } from './variants/contextualhelp_variants'
+import { SmallEmptyState, EmptyStateComplete } from './variants/emptystate_variants'
 import { InputWithPrefix, ErrorInput } from './variants/input_variants'
 import { ResizableTextarea } from './variants/textarea_variants'
 import { DefaultSearch, LoadingSearch } from './variants/search_variants'
 import { DefaultSelect } from './variants/select_variants'
-import { DefaultDatePicker } from './variants/datepicker_variants'
+import { DefaultDatePicker, DatePickerControlled } from './variants/datepicker_variants'
+import { DefaultDateRangePicker, DateRangePickerControlled } from './variants/daterangepicker_variants'
 import { DefaultTimeInput } from './variants/timeinput_variants'
 import { TooltipTop } from './variants/tooltip_variants'
 import { ExternalLink } from './variants/link_variants'
+import { DefaultPage, PageNarrow } from './variants/page_variants'
 import { DefaultPagination } from './variants/pagination_variants'
+import { DefaultRadioGroup, HorizontalRadioGroup } from './variants/radiogroup_variants'
+import { DefaultSpinner } from './variants/spinner_variants'
+import { DefaultTabList, TabListWithThreeTabs } from './variants/tablist_variants'
+import { DefaultTable, TableWithTags } from './variants/table_variants'
 ```
 
 ## How to Add New Variants
@@ -247,4 +333,4 @@ import { DefaultPagination } from './variants/pagination_variants'
 - ✅ **Maintainable**: Easy to see all variants at a glance
 - ✅ **Consistent naming**: Clear convention with `ComponentVariant` pattern
 - ✅ **Complete coverage**: Covers all visual variations and common states
-- ✅ **Comprehensive**: 24 components with 100+ variants total
+- ✅ **Comprehensive**: 35 components with 139+ variants total

--- a/packages/docs/examples/variants/checkboxgroup_variants.tsx
+++ b/packages/docs/examples/variants/checkboxgroup_variants.tsx
@@ -1,0 +1,63 @@
+import { Checkbox, CheckboxGroup } from '@vtex/shoreline'
+
+export function DefaultCheckboxGroup() {
+  return (
+    <CheckboxGroup label="Checkbox group">
+      <Checkbox value="1">Option 1</Checkbox>
+      <Checkbox value="2">Option 2</Checkbox>
+      <Checkbox value="3">Option 3</Checkbox>
+    </CheckboxGroup>
+  )
+}
+
+export function HorizontalCheckboxGroup() {
+  return (
+    <CheckboxGroup label="Horizontal checkbox group" horizontal>
+      <Checkbox value="1">Option 1</Checkbox>
+      <Checkbox value="2">Option 2</Checkbox>
+      <Checkbox value="3">Option 3</Checkbox>
+    </CheckboxGroup>
+  )
+}
+
+export function CheckboxGroupWithError() {
+  return (
+    <CheckboxGroup
+      label="Checkbox group with error"
+      error
+      errorText="Something is wrong"
+    >
+      <Checkbox value="1">Option 1</Checkbox>
+      <Checkbox value="2">Option 2</Checkbox>
+      <Checkbox value="3">Option 3</Checkbox>
+    </CheckboxGroup>
+  )
+}
+
+export function CheckboxGroupWithDescription() {
+  return (
+    <CheckboxGroup
+      label="Checkbox group with description"
+      description="Please select all that apply"
+    >
+      <Checkbox value="1">Option 1</Checkbox>
+      <Checkbox value="2">Option 2</Checkbox>
+      <Checkbox value="3">Option 3</Checkbox>
+    </CheckboxGroup>
+  )
+}
+
+export function HorizontalCheckboxGroupWithError() {
+  return (
+    <CheckboxGroup
+      label="Horizontal checkbox group with error"
+      horizontal
+      error
+      errorText="Something is wrong"
+    >
+      <Checkbox value="1">Option 1</Checkbox>
+      <Checkbox value="2">Option 2</Checkbox>
+      <Checkbox value="3">Option 3</Checkbox>
+    </CheckboxGroup>
+  )
+}

--- a/packages/docs/examples/variants/collection_variants.tsx
+++ b/packages/docs/examples/variants/collection_variants.tsx
@@ -1,0 +1,53 @@
+import {
+  Collection,
+  CollectionRow,
+  CollectionView,
+  Pagination,
+  Search,
+} from '@vtex/shoreline'
+import { DecorativeBox } from '../components/decorative-box'
+
+export function DefaultCollection() {
+  return (
+    <Collection>
+      <CollectionRow>
+        <Search />
+        <Pagination page={1} total={74} />
+      </CollectionRow>
+      <CollectionView status="ready">
+        <DecorativeBox subtle height="25rem" />
+      </CollectionView>
+      <CollectionRow align="flex-end">
+        <Pagination page={1} total={74} />
+      </CollectionRow>
+    </Collection>
+  )
+}
+
+export function CollectionWithContent() {
+  return (
+    <Collection>
+      <CollectionView status="ready">
+        <CollectionRow>Item 1</CollectionRow>
+        <CollectionRow>Item 2</CollectionRow>
+        <CollectionRow>Item 3</CollectionRow>
+      </CollectionView>
+    </Collection>
+  )
+}
+
+export function CollectionWithAlignedRow() {
+  return (
+    <Collection>
+      <CollectionRow align="flex-start">
+        <Search />
+      </CollectionRow>
+      <CollectionView status="ready">
+        <DecorativeBox subtle height="20rem" />
+      </CollectionView>
+      <CollectionRow align="center">
+        <Pagination page={1} total={50} />
+      </CollectionRow>
+    </Collection>
+  )
+}

--- a/packages/docs/examples/variants/collection_variants.tsx
+++ b/packages/docs/examples/variants/collection_variants.tsx
@@ -5,7 +5,7 @@ import {
   Pagination,
   Search,
 } from '@vtex/shoreline'
-import { DecorativeBox } from '../components/decorative-box'
+import { DecorativeBox } from '../../components/decorative-box'
 
 export function DefaultCollection() {
   return (

--- a/packages/docs/examples/variants/confirmationmodal_variants.tsx
+++ b/packages/docs/examples/variants/confirmationmodal_variants.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { Button, ConfirmationModal, Text } from '@vtex/shoreline'
+
+export function DefaultConfirmationModal() {
+  const [open, setOpen] = useState(false)
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>Open Confirmation Modal</Button>
+      <ConfirmationModal
+        open={open}
+        onClose={handleClose}
+        onConfirm={handleClose}
+        onCancel={handleClose}
+      >
+        <Text variant="body">Are you sure you want to proceed?</Text>
+      </ConfirmationModal>
+    </>
+  )
+}
+
+export function ConfirmationModalWithCustomText() {
+  const [open, setOpen] = useState(false)
+
+  const handleClose = () => {
+    setOpen(false)
+  }
+
+  return (
+    <>
+      <Button onClick={() => setOpen(true)}>
+        Open Custom Confirmation Modal
+      </Button>
+      <ConfirmationModal
+        open={open}
+        onClose={handleClose}
+        onConfirm={handleClose}
+        onCancel={handleClose}
+      >
+        <Text variant="body">
+          This action cannot be undone. Are you absolutely sure you want to
+          delete this item?
+        </Text>
+      </ConfirmationModal>
+    </>
+  )
+}

--- a/packages/docs/examples/variants/contextualhelp_variants.tsx
+++ b/packages/docs/examples/variants/contextualhelp_variants.tsx
@@ -1,0 +1,45 @@
+import { ContextualHelp } from '@vtex/shoreline'
+
+export function DefaultContextualHelp() {
+  return (
+    <ContextualHelp label="Help">
+      This is a contextual help message providing additional information.
+    </ContextualHelp>
+  )
+}
+
+export function ContextualHelpTopStart() {
+  return (
+    <ContextualHelp placement="top-start" label="Message">
+      Visits to the store which can include a series of user interactions and
+      end after 30 minutes of inactivity.
+    </ContextualHelp>
+  )
+}
+
+export function ContextualHelpBottomStart() {
+  return (
+    <ContextualHelp placement="bottom-start" label="Message">
+      Visits to the store which can include a series of user interactions and
+      end after 30 minutes of inactivity.
+    </ContextualHelp>
+  )
+}
+
+export function ContextualHelpTopEnd() {
+  return (
+    <ContextualHelp placement="top-end" label="Message">
+      Visits to the store which can include a series of user interactions and
+      end after 30 minutes of inactivity.
+    </ContextualHelp>
+  )
+}
+
+export function ContextualHelpBottomEnd() {
+  return (
+    <ContextualHelp placement="bottom-end" label="Message">
+      Visits to the store which can include a series of user interactions and
+      end after 30 minutes of inactivity.
+    </ContextualHelp>
+  )
+}

--- a/packages/docs/examples/variants/datepicker_variants.tsx
+++ b/packages/docs/examples/variants/datepicker_variants.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react'
 import { DatePicker } from '@vtex/shoreline'
+import { getLocalTimeZone, today } from '@vtex/shoreline/src/components/utils'
 
 export function DefaultDatePicker() {
   return <DatePicker />
@@ -10,4 +12,15 @@ export function DisabledDatePicker() {
 
 export function ReadOnlyDatePicker() {
   return <DatePicker isReadOnly />
+}
+
+export function DatePickerWithError() {
+  return <DatePicker error />
+}
+
+export function DatePickerControlled() {
+  const now = today(getLocalTimeZone())
+  const [value, setValue] = useState(now)
+
+  return <DatePicker value={value} onChange={setValue} />
 }

--- a/packages/docs/examples/variants/daterangepicker_variants.tsx
+++ b/packages/docs/examples/variants/daterangepicker_variants.tsx
@@ -1,0 +1,29 @@
+import { useState } from 'react'
+import { DateRangePicker } from '@vtex/shoreline'
+import { getLocalTimeZone, today } from '@vtex/shoreline/src/components/utils'
+
+export function DefaultDateRangePicker() {
+  return <DateRangePicker />
+}
+
+export function DisabledDateRangePicker() {
+  return <DateRangePicker isDisabled />
+}
+
+export function ReadOnlyDateRangePicker() {
+  return <DateRangePicker isReadOnly />
+}
+
+export function DateRangePickerWithError() {
+  return <DateRangePicker error />
+}
+
+export function DateRangePickerControlled() {
+  const now = today(getLocalTimeZone())
+  const [value, setValue] = useState({
+    start: now,
+    end: now.add({ days: 2 }),
+  })
+
+  return <DateRangePicker value={value} onChange={setValue} />
+}

--- a/packages/docs/examples/variants/emptystate_variants.tsx
+++ b/packages/docs/examples/variants/emptystate_variants.tsx
@@ -1,4 +1,13 @@
-import { EmptyState, Heading, Text } from '@vtex/shoreline'
+import {
+  EmptyState,
+  EmptyStateIllustration,
+  EmptyStateActions,
+  Heading,
+  Text,
+  Button,
+  IconXCircle,
+  IconWarningCircle,
+} from '@vtex/shoreline'
 
 export function SmallEmptyState() {
   return (
@@ -23,6 +32,46 @@ export function LargeEmptyState() {
     <EmptyState size="large">
       <Heading>Large Empty State</Heading>
       <Text variant="body">This is a large empty state</Text>
+    </EmptyState>
+  )
+}
+
+export function EmptyStateWithIllustration() {
+  return (
+    <EmptyState size="small">
+      <EmptyStateIllustration>
+        <IconXCircle color="var(--sl-color-gray-8)" />
+      </EmptyStateIllustration>
+      <Text variant="emphasis">No items available</Text>
+    </EmptyState>
+  )
+}
+
+export function EmptyStateWithActions() {
+  return (
+    <EmptyState>
+      <Heading>Title goes here</Heading>
+      <EmptyStateActions>
+        <Button variant="primary">Primary action</Button>
+      </EmptyStateActions>
+    </EmptyState>
+  )
+}
+
+export function EmptyStateComplete() {
+  return (
+    <EmptyState>
+      <EmptyStateIllustration>
+        <IconWarningCircle color="var(--sl-color-gray-8)" />
+      </EmptyStateIllustration>
+      <Heading>No products found</Heading>
+      <Text variant="body">
+        Get started by creating your first product using the button below.
+      </Text>
+      <EmptyStateActions>
+        <Button variant="primary">Create product</Button>
+        <Button variant="tertiary">Learn more</Button>
+      </EmptyStateActions>
     </EmptyState>
   )
 }

--- a/packages/docs/examples/variants/page_variants.tsx
+++ b/packages/docs/examples/variants/page_variants.tsx
@@ -1,0 +1,64 @@
+import {
+  Page,
+  PageContent,
+  PageHeader,
+  PageHeaderRow,
+  PageHeading,
+  Button,
+  Text,
+} from '@vtex/shoreline'
+
+export function DefaultPage() {
+  return (
+    <Page>
+      <PageHeader>
+        <PageHeading>Products</PageHeading>
+      </PageHeader>
+      <PageContent>
+        <Text variant="body">This is the page content</Text>
+      </PageContent>
+    </Page>
+  )
+}
+
+export function PageWithButton() {
+  return (
+    <Page>
+      <PageHeader>
+        <PageHeaderRow>
+          <PageHeading>Products</PageHeading>
+          <Button variant="primary">Add Product</Button>
+        </PageHeaderRow>
+      </PageHeader>
+      <PageContent>
+        <Text variant="body">This is the page content</Text>
+      </PageContent>
+    </Page>
+  )
+}
+
+export function PageNarrow() {
+  return (
+    <Page>
+      <PageHeader>
+        <PageHeading>Settings</PageHeading>
+      </PageHeader>
+      <PageContent layout="narrow">
+        <Text variant="body">This page has a narrow content layout</Text>
+      </PageContent>
+    </Page>
+  )
+}
+
+export function PageWide() {
+  return (
+    <Page>
+      <PageHeader>
+        <PageHeading>Dashboard</PageHeading>
+      </PageHeader>
+      <PageContent layout="wide">
+        <Text variant="body">This page has a wide content layout</Text>
+      </PageContent>
+    </Page>
+  )
+}

--- a/packages/docs/examples/variants/radiogroup_variants.tsx
+++ b/packages/docs/examples/variants/radiogroup_variants.tsx
@@ -1,0 +1,68 @@
+import { Radio, RadioGroup } from '@vtex/shoreline'
+
+export function DefaultRadioGroup() {
+  return (
+    <RadioGroup label="Vertical radio group">
+      <Radio value="apple-value">Apples</Radio>
+      <Radio value="pineapple-value">Pineapples</Radio>
+      <Radio value="orange-value">Oranges</Radio>
+      <Radio value="watermelon-value">Watermelons</Radio>
+    </RadioGroup>
+  )
+}
+
+export function HorizontalRadioGroup() {
+  return (
+    <RadioGroup label="Horizontal radio group" horizontal>
+      <Radio value="apple-value">Apples</Radio>
+      <Radio value="pineapple-value">Pineapples</Radio>
+      <Radio value="orange-value">Oranges</Radio>
+      <Radio value="watermelon-value">Watermelons</Radio>
+    </RadioGroup>
+  )
+}
+
+export function RadioGroupWithError() {
+  return (
+    <RadioGroup
+      label="Vertical radio group with error"
+      errorText="Something is wrong"
+      error
+    >
+      <Radio value="apple-value">Apples</Radio>
+      <Radio value="pineapple-value">Pineapples</Radio>
+      <Radio value="orange-value">Oranges</Radio>
+      <Radio value="watermelon-value">Watermelons</Radio>
+    </RadioGroup>
+  )
+}
+
+export function RadioGroupWithDescription() {
+  return (
+    <RadioGroup
+      label="Vertical radio group with description"
+      description="Please select your favorite fruit"
+    >
+      <Radio value="apple-value">Apples</Radio>
+      <Radio value="pineapple-value">Pineapples</Radio>
+      <Radio value="orange-value">Oranges</Radio>
+      <Radio value="watermelon-value">Watermelons</Radio>
+    </RadioGroup>
+  )
+}
+
+export function HorizontalRadioGroupWithError() {
+  return (
+    <RadioGroup
+      label="Horizontal radio group with error"
+      horizontal
+      errorText="Something is wrong"
+      error
+    >
+      <Radio value="apple-value">Apples</Radio>
+      <Radio value="pineapple-value">Pineapples</Radio>
+      <Radio value="orange-value">Oranges</Radio>
+      <Radio value="watermelon-value">Watermelons</Radio>
+    </RadioGroup>
+  )
+}

--- a/packages/docs/examples/variants/spinner_variants.tsx
+++ b/packages/docs/examples/variants/spinner_variants.tsx
@@ -1,0 +1,9 @@
+import { Spinner } from '@vtex/shoreline'
+
+export function DefaultSpinner() {
+  return <Spinner description="loading" />
+}
+
+export function SpinnerWithCustomDescription() {
+  return <Spinner description="Processing your request..." />
+}

--- a/packages/docs/examples/variants/table_variants.tsx
+++ b/packages/docs/examples/variants/table_variants.tsx
@@ -1,0 +1,137 @@
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Tag,
+} from '@vtex/shoreline'
+
+export function DefaultTable() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHeaderCell>Name</TableHeaderCell>
+          <TableHeaderCell>Description</TableHeaderCell>
+          <TableHeaderCell>Brand</TableHeaderCell>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>iPhone 15</TableCell>
+          <TableCell>A nice phone</TableCell>
+          <TableCell>Apple</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Aventador SVJ</TableCell>
+          <TableCell>Good italian car</TableCell>
+          <TableCell>Lamborghini</TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Uno with stair</TableCell>
+          <TableCell>Fastest car on earth</TableCell>
+          <TableCell>Fiat</TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  )
+}
+
+export function TableWithTags() {
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <TableHeaderCell>Name</TableHeaderCell>
+          <TableHeaderCell>Description</TableHeaderCell>
+          <TableHeaderCell>Brand</TableHeaderCell>
+          <TableHeaderCell>Category</TableHeaderCell>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>iPhone 15</TableCell>
+          <TableCell>A nice phone</TableCell>
+          <TableCell>Apple</TableCell>
+          <TableCell>
+            <Tag variant="secondary">smartphones</Tag>
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Aventador SVJ</TableCell>
+          <TableCell>Good italian car</TableCell>
+          <TableCell>Lamborghini</TableCell>
+          <TableCell>
+            <Tag variant="secondary" color="cyan">
+              cars
+            </Tag>
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Uno with stair</TableCell>
+          <TableCell>Fastest car on earth</TableCell>
+          <TableCell>Fiat</TableCell>
+          <TableCell>
+            <Tag variant="secondary" color="cyan">
+              cars
+            </Tag>
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  )
+}
+
+export function TableWithCustomWidths() {
+  return (
+    <Table
+      columnWidths={[
+        'minmax(min-content, auto)',
+        'minmax(min-content, auto)',
+        'minmax(min-content, auto)',
+        'minmax(min-content, auto)',
+      ]}
+    >
+      <TableHeader>
+        <TableRow>
+          <TableHeaderCell>Name</TableHeaderCell>
+          <TableHeaderCell>Description</TableHeaderCell>
+          <TableHeaderCell>Brand</TableHeaderCell>
+          <TableHeaderCell>Category</TableHeaderCell>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        <TableRow>
+          <TableCell>iPhone 15</TableCell>
+          <TableCell>A nice phone</TableCell>
+          <TableCell>Apple</TableCell>
+          <TableCell>
+            <Tag variant="secondary">smartphones</Tag>
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Aventador SVJ</TableCell>
+          <TableCell>Good italian car</TableCell>
+          <TableCell>Lamborghini</TableCell>
+          <TableCell>
+            <Tag variant="secondary" color="cyan">
+              cars
+            </Tag>
+          </TableCell>
+        </TableRow>
+        <TableRow>
+          <TableCell>Uno with stair</TableCell>
+          <TableCell>Fastest car on earth</TableCell>
+          <TableCell>Fiat</TableCell>
+          <TableCell>
+            <Tag variant="secondary" color="cyan">
+              cars
+            </Tag>
+          </TableCell>
+        </TableRow>
+      </TableBody>
+    </Table>
+  )
+}

--- a/packages/docs/examples/variants/tablist_variants.tsx
+++ b/packages/docs/examples/variants/tablist_variants.tsx
@@ -1,0 +1,65 @@
+import { Tab, TabList, TabPanel, TabProvider } from '@vtex/shoreline'
+import { DecorativeBox } from '../components/decorative-box'
+
+export function DefaultTabList() {
+  return (
+    <TabProvider>
+      <TabList>
+        <Tab>Tab 1</Tab>
+        <Tab>Tab 2</Tab>
+      </TabList>
+      <TabPanel>
+        <DecorativeBox height="200px" color="blue" />
+      </TabPanel>
+      <TabPanel>
+        <DecorativeBox height="200px" color="green" />
+      </TabPanel>
+    </TabProvider>
+  )
+}
+
+export function TabListWithThreeTabs() {
+  return (
+    <TabProvider>
+      <TabList>
+        <Tab>Blue</Tab>
+        <Tab>Green</Tab>
+        <Tab>Purple</Tab>
+      </TabList>
+      <TabPanel>
+        <DecorativeBox height="200px" color="blue" />
+      </TabPanel>
+      <TabPanel>
+        <DecorativeBox height="200px" color="green" />
+      </TabPanel>
+      <TabPanel>
+        <DecorativeBox height="200px" color="purple" />
+      </TabPanel>
+    </TabProvider>
+  )
+}
+
+export function TabListWithMultiplePanels() {
+  return (
+    <TabProvider>
+      <TabList>
+        <Tab>Products</Tab>
+        <Tab>Categories</Tab>
+        <Tab>Analytics</Tab>
+        <Tab>Settings</Tab>
+      </TabList>
+      <TabPanel>
+        <DecorativeBox height="250px" color="blue" />
+      </TabPanel>
+      <TabPanel>
+        <DecorativeBox height="250px" color="green" />
+      </TabPanel>
+      <TabPanel>
+        <DecorativeBox height="250px" color="purple" />
+      </TabPanel>
+      <TabPanel>
+        <DecorativeBox height="250px" color="orange" />
+      </TabPanel>
+    </TabProvider>
+  )
+}

--- a/packages/docs/examples/variants/tablist_variants.tsx
+++ b/packages/docs/examples/variants/tablist_variants.tsx
@@ -1,5 +1,5 @@
 import { Tab, TabList, TabPanel, TabProvider } from '@vtex/shoreline'
-import { DecorativeBox } from '../components/decorative-box'
+import { DecorativeBox } from '../../components/decorative-box'
 
 export function DefaultTabList() {
   return (


### PR DESCRIPTION
## Summary
- Fixes the `build-docs` compilation error caused by wrong relative import paths for `DecorativeBox` in `collection_variants.tsx` and `tablist_variants.tsx`.
- Changed `'../components/decorative-box'` to `'../../components/decorative-box'` since the files are two directory levels deep (`examples/variants/`).

## Test plan
- [x] `pnpm build:docs` completes successfully.

This PR is a duplicate from #2123 