### PR TITLE
feat(charts): package scaffold and internal core

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -1,0 +1,56 @@
+{
+  "name": "@vtex/shoreline-charts",
+  "description": "Shoreline data visualization components",
+  "version": "0.0.0",
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./css": "./dist/styles.css",
+    "./css/unlayered": "./dist/styles-unlayered.css"
+  },
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "prebuild": "rm -rf dist",
+    "dev": "concurrently \"tsup --watch\" \"pnpm run build:css\"",
+    "build": "pnpm run prebuild && tsc --noEmit && concurrently \"tsup\" \"pnpm run build:css\"",
+    "build:css": "node -r sucrase/register src/scripts/build-css.ts"
+  },
+  "repository": {
+    "directory": "packages/charts",
+    "type": "git",
+    "url": "git+https://github.com/vtex/shoreline.git"
+  },
+  "bugs": {
+    "url": "https://github.com/vtex/shoreline/issues"
+  },
+  "peerDependencies": {
+    "react": ">=18.3",
+    "react-dom": ">=18.3",
+    "typescript": ">=5"
+  },
+  "devDependencies": {
+    "@types/node": "20.14.9",
+    "@vtex/shoreline-css": "workspace:*",
+    "concurrently": "8.2.2",
+    "sucrase": "3.35.0"
+  },
+  "dependencies": {
+    "@vtex/shoreline-utils": "workspace:*",
+    "echarts": "5.6.0"
+  }
+}

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -1,0 +1,6 @@
+/**
+ * Public chart components (BarChart, LineChart, AreaChart) land in later PRs.
+ * Everything under ./internal is an implementation detail and MUST NOT be
+ * exported from this barrel — the chart engine never leaks into the public API.
+ */
+export {}

--- a/packages/charts/src/internal/chart-container/chart-container.css
+++ b/packages/charts/src/internal/chart-container/chart-container.css
@@ -1,0 +1,4 @@
+[data-sl-chart-container] {
+  inline-size: 100%;
+  block-size: 100%;
+}

--- a/packages/charts/src/internal/chart-container/chart-container.tsx
+++ b/packages/charts/src/internal/chart-container/chart-container.tsx
@@ -1,0 +1,83 @@
+import type { ComponentPropsWithoutRef, MutableRefObject } from 'react'
+import { forwardRef, useEffect, useRef } from 'react'
+import { useMergeRef } from '@vtex/shoreline-utils'
+
+import type { EChartsCoreOption, EChartsType } from '../echarts'
+import { init } from '../echarts'
+import { createChartTheme, createElementTokens } from '../theme'
+
+/**
+ * Hosts an engine instance inside a Shoreline-styled element: initializes it
+ * with the token-bridged theme, keeps it sized to the container, and disposes
+ * it on unmount. All engine access happens inside effects, so rendering is
+ * SSR-safe. Every public chart composes this container; it is never exported
+ * from the package.
+ */
+export const ChartContainer = forwardRef<HTMLDivElement, ChartContainerProps>(
+  function ChartContainer(props, ref) {
+    const { option, chartRef, ...htmlProps } = props
+
+    const containerRef = useRef<HTMLDivElement>(null)
+    const instanceRef = useRef<EChartsType | null>(null)
+
+    useEffect(() => {
+      const element = containerRef.current
+
+      if (!element) return
+
+      const chart = init(
+        element,
+        createChartTheme(createElementTokens(element)),
+        { renderer: 'svg' }
+      )
+
+      instanceRef.current = chart
+
+      const observer = new ResizeObserver(() => {
+        chart.resize()
+      })
+
+      observer.observe(element)
+
+      return () => {
+        observer.disconnect()
+        chart.dispose()
+        instanceRef.current = null
+      }
+    }, [])
+
+    useEffect(() => {
+      if (chartRef) {
+        chartRef.current = instanceRef.current
+      }
+    })
+
+    useEffect(() => {
+      instanceRef.current?.setOption(option, { notMerge: true })
+    }, [option])
+
+    return (
+      <div
+        data-sl-chart-container
+        ref={useMergeRef(ref, containerRef)}
+        {...htmlProps}
+      />
+    )
+  }
+)
+
+export interface ChartContainerOptions {
+  /**
+   * Engine option applied to the instance. Replaces the previous option
+   * entirely on every change, so charts derive it as a pure function of their
+   * props.
+   */
+  option: EChartsCoreOption
+  /**
+   * Imperative access to the engine instance, for internal use in tests.
+   */
+  chartRef?: MutableRefObject<EChartsType | null>
+}
+
+export type ChartContainerProps = ChartContainerOptions &
+  ComponentPropsWithoutRef<'div'>

--- a/packages/charts/src/internal/chart-container/index.ts
+++ b/packages/charts/src/internal/chart-container/index.ts
@@ -1,0 +1,5 @@
+export { ChartContainer } from './chart-container'
+export type {
+  ChartContainerOptions,
+  ChartContainerProps,
+} from './chart-container'

--- a/packages/charts/src/internal/chart-container/tests/chart-container.test.tsx
+++ b/packages/charts/src/internal/chart-container/tests/chart-container.test.tsx
@@ -1,0 +1,147 @@
+import { describe, expect, render, test, vi } from '@vtex/shoreline-test-utils'
+import { BarChart } from 'echarts/charts'
+import { GridComponent } from 'echarts/components'
+import type { MutableRefObject } from 'react'
+import { createRef } from 'react'
+
+import type { EChartsCoreOption, EChartsType } from '../../echarts'
+import { use } from '../../echarts'
+import { ChartContainer } from '../chart-container'
+
+// Charts register their own engine modules (see internal/echarts.ts); tests
+// stand in for the public charts of later PRs.
+use([BarChart, GridComponent])
+
+class ResizeObserverStub {
+  static instances: ResizeObserverStub[] = []
+
+  readonly targets: Element[] = []
+
+  constructor(readonly callback: ResizeObserverCallback) {
+    ResizeObserverStub.instances.push(this)
+  }
+
+  observe(target: Element) {
+    this.targets.push(target)
+  }
+
+  unobserve() {}
+
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+// jsdom does no layout, so give elements a size for the engine to render into
+vi.spyOn(Element.prototype, 'clientWidth', 'get').mockReturnValue(400)
+vi.spyOn(Element.prototype, 'clientHeight', 'get').mockReturnValue(300)
+
+// jsdom has no canvas implementation; the engine only uses the 2d context to
+// measure text, even when rendering to SVG.
+vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+  font: '',
+  measureText: (text: string) => ({ width: text.length * 8 }),
+} as unknown as CanvasRenderingContext2D)
+
+function chartRefStub(): MutableRefObject<EChartsType | null> {
+  return { current: null }
+}
+
+const option: EChartsCoreOption = {
+  xAxis: { type: 'category', data: ['A', 'B'] },
+  yAxis: { type: 'value' },
+  series: [{ type: 'bar', data: [1, 2] }],
+}
+
+describe('chart-container', () => {
+  test('renders the container element, forwarding ref and html props', () => {
+    const ref = createRef<HTMLDivElement>()
+
+    const { container } = render(
+      <ChartContainer ref={ref} option={option} id="revenue" />
+    )
+
+    const element = container.querySelector('[data-sl-chart-container]')
+
+    expect(element).toBeInTheDocument()
+    expect(element).toHaveAttribute('id', 'revenue')
+    expect(ref.current).toBe(element)
+  })
+
+  test('initializes the engine and applies the option', () => {
+    const chartRef = chartRefStub()
+
+    const { container } = render(
+      <ChartContainer option={option} chartRef={chartRef} />
+    )
+
+    const applied = chartRef.current?.getOption()
+
+    expect(applied?.series).toMatchObject([{ type: 'bar', data: [1, 2] }])
+    expect(applied?.xAxis).toMatchObject([{ data: ['A', 'B'] }])
+    expect(
+      container.querySelector('[data-sl-chart-container] svg')
+    ).toBeInTheDocument()
+  })
+
+  test('replaces the option when the prop changes', () => {
+    const chartRef = chartRefStub()
+
+    const { rerender } = render(
+      <ChartContainer option={option} chartRef={chartRef} />
+    )
+
+    rerender(
+      <ChartContainer
+        option={{
+          ...option,
+          series: [{ type: 'bar', data: [3, 4] }],
+        }}
+        chartRef={chartRef}
+      />
+    )
+
+    expect(chartRef.current?.getOption()?.series).toMatchObject([
+      { type: 'bar', data: [3, 4] },
+    ])
+  })
+
+  test('resizes the chart when the container resizes', () => {
+    const chartRef = chartRefStub()
+
+    const { container } = render(
+      <ChartContainer option={option} chartRef={chartRef} />
+    )
+
+    const chart = chartRef.current
+
+    if (!chart) throw new Error('chart was not initialized')
+
+    const resize = vi.spyOn(chart, 'resize')
+    const observer = ResizeObserverStub.instances.at(-1)
+
+    expect(observer?.targets).toContain(
+      container.querySelector('[data-sl-chart-container]')
+    )
+
+    observer?.callback([], observer as unknown as ResizeObserver)
+
+    expect(resize).toHaveBeenCalled()
+  })
+
+  test('disposes the engine instance on unmount', () => {
+    const chartRef = chartRefStub()
+
+    const { unmount } = render(
+      <ChartContainer option={option} chartRef={chartRef} />
+    )
+
+    const chart = chartRef.current
+
+    if (!chart) throw new Error('chart was not initialized')
+
+    unmount()
+
+    expect(chart.isDisposed()).toBe(true)
+  })
+})

--- a/packages/charts/src/internal/echarts.ts
+++ b/packages/charts/src/internal/echarts.ts
@@ -1,0 +1,18 @@
+import { AriaComponent } from 'echarts/components'
+import { init, use } from 'echarts/core'
+import { SVGRenderer } from 'echarts/renderers'
+
+/**
+ * Engine modules required by every chart. Chart types (bar, line, …) and the
+ * components they need (grid, tooltip, legend, …) are registered by each
+ * chart's own module, keeping consumer bundles tree-shaken to the charts they
+ * actually import.
+ *
+ * SVG is the only registered renderer: Admin-scale datasets don't need canvas
+ * performance, and SVG output produces crisp, stable Chromatic diffs where
+ * canvas screenshots diff noisily.
+ */
+use([SVGRenderer, AriaComponent])
+
+export { init, use }
+export type { EChartsCoreOption, EChartsType } from 'echarts/core'

--- a/packages/charts/src/internal/theme/chart-theme.ts
+++ b/packages/charts/src/internal/theme/chart-theme.ts
@@ -1,0 +1,89 @@
+/**
+ * Resolves `--sl-*` design tokens to concrete values. Values come from the
+ * computed styles of the chart's own DOM element (see `createElementTokens`),
+ * so token updates propagate to charts without a package release.
+ */
+export interface ChartTokens {
+  /**
+   * Raw resolved token value, or undefined when the token can't be resolved
+   * (e.g. the Shoreline stylesheet isn't loaded).
+   */
+  get: (token: string) => string | undefined
+  /**
+   * Token length resolved to a px number (the engine only accepts px), or
+   * undefined when the token can't be resolved.
+   */
+  px: (token: string) => number | undefined
+}
+
+/**
+ * Categorical series palette, assigned to series in this fixed order (never
+ * cycled). The order interleaves warm and cool hues so adjacent series stay
+ * distinguishable under color-vision deficiency (worst adjacent-pair CVD
+ * ΔE 17.1 against the base surface). Provisional until designer sign-off on
+ * the Data Visualization spec.
+ */
+export const chartSeriesTokens = [
+  '--sl-color-blue-9',
+  '--sl-color-orange-9',
+  '--sl-color-teal-9',
+  '--sl-color-pink-9',
+  '--sl-color-green-9',
+  '--sl-color-purple-9',
+  '--sl-color-yellow-9',
+  '--sl-color-cyan-9',
+]
+
+const fontFamily = '--sl-font-family-sans'
+const fontSizeCaption = '--sl-font-size-1'
+const fgBase = '--sl-fg-base'
+const fgMuted = '--sl-fg-muted'
+// color component of --sl-border-base, which is a full border shorthand
+const lineColor = '--sl-color-gray-3'
+
+/**
+ * Compiles `--sl-*` design tokens into an engine theme object. This bridge is
+ * the only path style reaches the engine: charts render to SVG, so CSS can't
+ * style them directly. Unresolvable tokens compile to undefined, which the
+ * engine ignores in favor of its defaults.
+ */
+export function createChartTheme(tokens: ChartTokens) {
+  const { get, px } = tokens
+
+  const palette = chartSeriesTokens
+    .map(get)
+    .filter((color): color is string => Boolean(color))
+
+  const label = {
+    color: get(fgMuted),
+    fontFamily: get(fontFamily),
+    fontSize: px(fontSizeCaption),
+  }
+
+  const axis = {
+    axisLine: { lineStyle: { color: get(lineColor) } },
+    axisTick: { lineStyle: { color: get(lineColor) } },
+    axisLabel: label,
+    splitLine: { lineStyle: { color: get(lineColor) } },
+  }
+
+  return {
+    color: palette.length > 0 ? palette : undefined,
+    backgroundColor: 'transparent',
+    textStyle: {
+      color: get(fgBase),
+      fontFamily: get(fontFamily),
+    },
+    categoryAxis: axis,
+    valueAxis: axis,
+    legend: {
+      textStyle: {
+        color: get(fgBase),
+        fontFamily: get(fontFamily),
+        fontSize: px(fontSizeCaption),
+      },
+    },
+  }
+}
+
+export type ChartTheme = ReturnType<typeof createChartTheme>

--- a/packages/charts/src/internal/theme/element-tokens.ts
+++ b/packages/charts/src/internal/theme/element-tokens.ts
@@ -1,0 +1,43 @@
+import type { ChartTokens } from './chart-theme'
+
+const remBase = 16
+
+function parsePx(value: string) {
+  const parsed = Number.parseFloat(value)
+
+  return Number.isNaN(parsed) ? undefined : parsed
+}
+
+/**
+ * Reads `--sl-*` tokens from an element's computed styles, so the values
+ * reflect the full cascade at the chart's position in the document. Must only
+ * be called in the browser (e.g. inside an effect).
+ */
+export function createElementTokens(element: HTMLElement): ChartTokens {
+  const computed = getComputedStyle(element)
+  const rootFontSize =
+    parsePx(getComputedStyle(element.ownerDocument.documentElement).fontSize) ??
+    remBase
+
+  const get = (token: string) => {
+    const value = computed.getPropertyValue(token).trim()
+
+    return value === '' ? undefined : value
+  }
+
+  const px = (token: string) => {
+    const value = get(token)
+
+    if (!value) return undefined
+    if (value.endsWith('rem')) {
+      const parsed = parsePx(value)
+
+      return parsed !== undefined ? parsed * rootFontSize : undefined
+    }
+    if (value.endsWith('px')) return parsePx(value)
+
+    return undefined
+  }
+
+  return { get, px }
+}

--- a/packages/charts/src/internal/theme/index.ts
+++ b/packages/charts/src/internal/theme/index.ts
@@ -1,0 +1,3 @@
+export { chartSeriesTokens, createChartTheme } from './chart-theme'
+export type { ChartTheme, ChartTokens } from './chart-theme'
+export { createElementTokens } from './element-tokens'

--- a/packages/charts/src/internal/theme/tests/chart-theme.test.ts
+++ b/packages/charts/src/internal/theme/tests/chart-theme.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from 'vitest'
+
+import type { ChartTokens } from '../chart-theme'
+import { chartSeriesTokens, createChartTheme } from '../chart-theme'
+
+function fakeTokens(values: Record<string, string | number>): ChartTokens {
+  return {
+    get: (token) => {
+      const value = values[token]
+
+      return value === undefined ? undefined : String(value)
+    },
+    px: (token) => {
+      const value = values[token]
+
+      return typeof value === 'number' ? value : undefined
+    },
+  }
+}
+
+describe('createChartTheme', () => {
+  test('builds the series palette from tokens in fixed order', () => {
+    const theme = createChartTheme(
+      fakeTokens(
+        Object.fromEntries(
+          chartSeriesTokens.map((token, i) => [token, `#00000${i}`])
+        )
+      )
+    )
+
+    expect(theme.color).toEqual(chartSeriesTokens.map((_, i) => `#00000${i}`))
+  })
+
+  test('drops unresolvable palette entries without reordering', () => {
+    const [first, , third] = chartSeriesTokens
+
+    const theme = createChartTheme(
+      fakeTokens({ [first]: '#111111', [third]: '#333333' })
+    )
+
+    expect(theme.color).toEqual(['#111111', '#333333'])
+  })
+
+  test('omits the palette entirely when no token resolves', () => {
+    const theme = createChartTheme(fakeTokens({}))
+
+    expect(theme.color).toBeUndefined()
+  })
+
+  test('maps typography and foreground tokens', () => {
+    const theme = createChartTheme(
+      fakeTokens({
+        '--sl-font-family-sans': 'VTEX Trust',
+        '--sl-font-size-1': 12,
+        '--sl-fg-base': '#07080a',
+        '--sl-fg-muted': '#3d3d3d',
+      })
+    )
+
+    expect(theme.textStyle).toEqual({
+      color: '#07080a',
+      fontFamily: 'VTEX Trust',
+    })
+    expect(theme.categoryAxis.axisLabel).toEqual({
+      color: '#3d3d3d',
+      fontFamily: 'VTEX Trust',
+      fontSize: 12,
+    })
+    expect(theme.legend.textStyle).toEqual({
+      color: '#07080a',
+      fontFamily: 'VTEX Trust',
+      fontSize: 12,
+    })
+  })
+
+  test('maps axis line colors on both axis types', () => {
+    const theme = createChartTheme(fakeTokens({ '--sl-color-gray-3': '#ddd' }))
+
+    for (const axis of [theme.categoryAxis, theme.valueAxis]) {
+      expect(axis.axisLine.lineStyle.color).toBe('#ddd')
+      expect(axis.axisTick.lineStyle.color).toBe('#ddd')
+      expect(axis.splitLine.lineStyle.color).toBe('#ddd')
+    }
+  })
+
+  test('keeps the chart background transparent so surfaces show through', () => {
+    expect(createChartTheme(fakeTokens({})).backgroundColor).toBe('transparent')
+  })
+})

--- a/packages/charts/src/internal/theme/tests/element-tokens.test.ts
+++ b/packages/charts/src/internal/theme/tests/element-tokens.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import { createElementTokens } from '../element-tokens'
+
+function stubComputedStyle(
+  values: Record<string, string>,
+  rootFontSize = '16px'
+) {
+  vi.stubGlobal(
+    'getComputedStyle',
+    vi.fn((target: Element) => {
+      const isRoot = target === document.documentElement
+
+      return {
+        fontSize: isRoot ? rootFontSize : '',
+        getPropertyValue: (property: string) =>
+          isRoot ? '' : (values[property] ?? ''),
+      }
+    })
+  )
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('createElementTokens', () => {
+  test('resolves tokens from the element computed style, trimmed', () => {
+    stubComputedStyle({ '--sl-fg-base': '  #07080a ' })
+    const tokens = createElementTokens(document.createElement('div'))
+
+    expect(tokens.get('--sl-fg-base')).toBe('#07080a')
+  })
+
+  test('resolves missing tokens to undefined', () => {
+    stubComputedStyle({})
+    const tokens = createElementTokens(document.createElement('div'))
+
+    expect(tokens.get('--sl-fg-base')).toBeUndefined()
+    expect(tokens.px('--sl-font-size-1')).toBeUndefined()
+  })
+
+  test('converts rem lengths to px using the document root font size', () => {
+    stubComputedStyle({ '--sl-font-size-1': '0.75rem' }, '20px')
+    const tokens = createElementTokens(document.createElement('div'))
+
+    expect(tokens.px('--sl-font-size-1')).toBe(15)
+  })
+
+  test('defaults the rem base to 16 when the root font size is unavailable', () => {
+    stubComputedStyle({ '--sl-font-size-1': '0.75rem' }, '')
+    const tokens = createElementTokens(document.createElement('div'))
+
+    expect(tokens.px('--sl-font-size-1')).toBe(12)
+  })
+
+  test('passes px lengths through and rejects other units', () => {
+    stubComputedStyle({
+      '--sl-size-a': '12px',
+      '--sl-size-b': '1.5em',
+    })
+    const tokens = createElementTokens(document.createElement('div'))
+
+    expect(tokens.px('--sl-size-a')).toBe(12)
+    expect(tokens.px('--sl-size-b')).toBeUndefined()
+  })
+})

--- a/packages/charts/src/scripts/build-css.ts
+++ b/packages/charts/src/scripts/build-css.ts
@@ -1,0 +1,21 @@
+import { bundle } from '@vtex/shoreline-css'
+
+export function build() {
+  const outdir = 'dist'
+  const inputFile = 'src/styles.css'
+
+  bundle({
+    inputFile,
+    outdir,
+    outputFile: 'styles',
+    layer: 'sl-components',
+  })
+
+  bundle({
+    inputFile,
+    outdir,
+    outputFile: 'styles',
+  })
+}
+
+build()

--- a/packages/charts/src/styles.css
+++ b/packages/charts/src/styles.css
@@ -1,0 +1,1 @@
+@import "./internal/chart-container/chart-container.css";

--- a/packages/charts/tsconfig.json
+++ b/packages/charts/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "declarationDir": "declarations"
+  },
+  "include": ["./src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/charts/tsup.config.ts
+++ b/packages/charts/tsup.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'tsup'
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['cjs', 'esm'],
+  external: ['react'],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  dts: true,
+  banner: {
+    js: "'use client'",
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,37 @@ importers:
         specifier: 7.2.0
         version: 7.2.0
 
+  packages/charts:
+    dependencies:
+      '@vtex/shoreline-utils':
+        specifier: workspace:*
+        version: link:../utils
+      echarts:
+        specifier: 5.6.0
+        version: 5.6.0
+      react:
+        specifier: '>=18.3'
+        version: 18.3.1
+      react-dom:
+        specifier: '>=18.3'
+        version: 18.3.1(react@18.3.1)
+      typescript:
+        specifier: '>=5'
+        version: 5.5.2
+    devDependencies:
+      '@types/node':
+        specifier: 20.14.9
+        version: 20.14.9
+      '@vtex/shoreline-css':
+        specifier: workspace:*
+        version: link:../css
+      concurrently:
+        specifier: 8.2.2
+        version: 8.2.2
+      sucrase:
+        specifier: 3.35.0
+        version: 3.35.0
+
   packages/css:
     dependencies:
       '@vtex/shoreline-utils':
@@ -5006,6 +5037,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  echarts@5.6.0:
+    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
     engines: {node: '>=0.10.0'}
@@ -9275,6 +9309,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
@@ -10034,10 +10071,6 @@ packages:
     resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
     engines: {node: '>=6'}
 
-  yargs-parser@20.2.4:
-    resolution: {integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==}
-    engines: {node: '>=10'}
-
   yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
     engines: {node: '>=10'}
@@ -10077,6 +10110,9 @@ packages:
 
   zod@3.25.58:
     resolution: {integrity: sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q==}
+
+  zrender@5.6.1:
+    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10426,7 +10462,7 @@ snapshots:
   '@commitlint/ensure@9.1.2':
     dependencies:
       '@commitlint/types': 9.1.2
-      lodash: 4.17.21
+      lodash: 4.18.1
 
   '@commitlint/execute-rule@19.0.0':
     optional: true
@@ -10436,7 +10472,7 @@ snapshots:
   '@commitlint/format@9.1.2':
     dependencies:
       '@commitlint/types': 9.1.2
-      chalk: 4.1.0
+      chalk: 4.1.2
 
   '@commitlint/is-ignored@9.1.2':
     dependencies:
@@ -10474,7 +10510,7 @@ snapshots:
       '@commitlint/types': 9.1.2
       chalk: 4.1.0
       cosmiconfig: 6.0.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       resolve-from: 5.0.0
 
   '@commitlint/message@9.1.2': {}
@@ -10512,7 +10548,7 @@ snapshots:
   '@commitlint/resolve-extends@9.1.2':
     dependencies:
       import-fresh: 3.3.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       resolve-from: 5.0.0
       resolve-global: 1.0.0
 
@@ -11222,7 +11258,7 @@ snapshots:
       js-yaml: 4.1.0
       libnpmpublish: 7.3.0
       load-json-file: 6.2.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       make-dir: 4.0.0
       minimatch: 3.0.5
       multimatch: 5.0.0
@@ -13086,7 +13122,7 @@ snapshots:
       '@storybook/types': 8.1.5
       '@types/qs': 6.9.15
       dequal: 2.0.3
-      lodash: 4.17.21
+      lodash: 4.18.1
       memoizerific: 1.11.3
       qs: 6.12.1
       tiny-invariant: 1.3.3
@@ -13363,7 +13399,7 @@ snapshots:
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
-      lodash: 4.17.21
+      lodash: 4.18.1
       redent: 3.0.0
 
   '@testing-library/react@14.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
@@ -14070,7 +14106,7 @@ snapshots:
 
   async@2.6.4:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
 
   async@3.2.5: {}
 
@@ -14662,7 +14698,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       date-fns: 2.30.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       rxjs: 7.8.1
       shell-quote: 1.8.1
       spawn-command: 0.0.2
@@ -14736,7 +14772,7 @@ snapshots:
     dependencies:
       JSONStream: 1.3.5
       is-text-path: 1.0.1
-      lodash: 4.17.21
+      lodash: 4.18.1
       meow: 8.1.2
       split2: 3.2.2
       through2: 4.0.2
@@ -15322,6 +15358,11 @@ snapshots:
   duplexer@0.1.2: {}
 
   eastasianwidth@0.2.0: {}
+
+  echarts@5.6.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 5.6.1
 
   ejs@3.1.10:
     dependencies:
@@ -15987,7 +16028,7 @@ snapshots:
   git-raw-commits@2.0.11:
     dependencies:
       dargs: 7.0.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       meow: 8.1.2
       split2: 3.2.2
       through2: 4.0.2
@@ -16402,7 +16443,7 @@ snapshots:
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.2.1
     optionalDependencies:
@@ -16600,7 +16641,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -16618,7 +16659,7 @@ snapshots:
       cli-width: 3.0.0
       external-editor: 3.1.0
       figures: 3.2.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       mute-stream: 0.0.8
       ora: 5.4.1
       run-async: 2.4.1
@@ -18141,7 +18182,7 @@ snapshots:
       redent: 3.0.0
       trim-newlines: 3.0.1
       type-fest: 0.18.1
-      yargs-parser: 20.2.4
+      yargs-parser: 20.2.9
 
   merge-stream@2.0.0: {}
 
@@ -19507,7 +19548,7 @@ snapshots:
 
   pretty-error@4.0.0:
     dependencies:
-      lodash: 4.17.21
+      lodash: 4.18.1
       renderkid: 3.0.0
 
   pretty-format@27.5.1:
@@ -19981,7 +20022,7 @@ snapshots:
       css-select: 4.3.0
       dom-converter: 0.2.0
       htmlparser2: 6.1.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       strip-ansi: 6.0.1
 
   require-directory@2.1.1: {}
@@ -20837,6 +20878,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.3.0: {}
+
   tslib@2.6.3: {}
 
   tsup@8.1.0(@swc/core@1.5.24(@swc/helpers@0.5.13))(postcss@8.4.47)(typescript@5.5.2):
@@ -21337,7 +21380,7 @@ snapshots:
       chalk: 1.1.3
       in-publish: 2.0.1
       inquirer: 0.11.0
-      lodash: 4.17.21
+      lodash: 4.18.1
       log-update: 1.0.2
       minimist: 1.2.8
       node-localstorage: 0.6.0
@@ -21637,8 +21680,6 @@ snapshots:
       camelcase: 5.3.1
       decamelize: 1.2.0
 
-  yargs-parser@20.2.4: {}
-
   yargs-parser@20.2.9: {}
 
   yargs-parser@21.1.1: {}
@@ -21692,5 +21733,9 @@ snapshots:
   zod@3.23.8: {}
 
   zod@3.25.58: {}
+
+  zrender@5.6.1:
+    dependencies:
+      tslib: 2.3.0
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
Stage-1 PR 1.1 of the charts spec (`shoreline-specs/specs/001-charts`): the `@vtex/shoreline-charts` package with its un-exported internal core.

- Engine setup via `echarts/core` with per-chart module registration and the SVG renderer (crisp Chromatic diffs, documented in `internal/echarts.ts`)
- Token→theme bridge compiling computed `--sl-*` custom properties into an engine theme at runtime; categorical palette order validated for adjacent CVD separation, provisional until designer sign-off in the BarChart PR
- `ChartContainer`: SSR-safe init/dispose lifecycle, ResizeObserver-driven resize, `data-sl-chart-container` styled in `@layer sl-components`
- Public barrel is intentionally empty — `BarChart` lands in the next stacked PR

## Review focus
Architecture: is the encapsulation and token bridge right? (per plan.md stage 1 table)

## Test plan
- [ ] `pnpm test:ci` passes for `packages/charts`
- [ ] `pnpm build` passes
- [ ] `pnpm lint` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the foundation for a new charts package with responsive chart rendering.
  - Charts now automatically apply Shoreline design tokens, including colors, typography, axes, labels, and legends.
  - Added SVG rendering and accessibility support.
  - Chart containers adapt to size changes and clean up resources when removed.
  - Added styling and build support for chart-related components.

- **Tests**
  - Added coverage for chart rendering, resizing, theme application, token handling, and cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->