### PR TITLE
feat(charts): add bar chart tooltip

### DIFF
--- a/packages/charts/src/components/bar-chart/bar-option.ts
+++ b/packages/charts/src/components/bar-chart/bar-option.ts
@@ -1,6 +1,7 @@
 import type { EChartsCoreOption } from '../../internal/echarts'
 import type { ChartTokens } from '../../internal/theme'
 import { chartSeriesTokens } from '../../internal/theme'
+import type { ChartTooltipDelta } from '../../internal/tooltip'
 import {
   createAxisTooltipFormatter,
   createTooltipPositioner,
@@ -19,6 +20,17 @@ export interface BarChartSeries {
    * that category.
    */
   data: Array<number | null>
+  /**
+   * How each value changed against whatever period it is being compared to,
+   * in category order alongside `data`; `null` or a short array leaves that
+   * category's row without a delta.
+   *
+   * Supplied explicitly rather than derived, because only the consumer knows
+   * what the comparison is and whether a move reads as good or bad. The
+   * comparison series need not be on the chart at all.
+   * @default undefined
+   */
+  deltas?: Array<ChartTooltipDelta | null>
 }
 
 /**
@@ -66,6 +78,10 @@ export const defaultMaxSeries = 3
  * Values are summed per category. A null contributes nothing, and a category
  * where every folded series is null stays null, so the aggregate renders no
  * bar rather than a spurious zero.
+ *
+ * The aggregate carries no deltas: they arrive already formatted, so there is
+ * no sound way to combine those of the series it replaces. Series that keep
+ * their own slot keep their own deltas.
  */
 export function collapseSeries(
   series: BarChartSeries[],
@@ -181,6 +197,19 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
   // the first series where the reader starts.
   const reverseTooltipRows = direction === 'vertical' && grouping === 'stacked'
 
+  // Rows name their series, so that name is what a delta is looked up by —
+  // the same key the legend and tooltip already identify a series with. Left
+  // undefined when no series supplied deltas, so the tooltip skips the lookup
+  // entirely for the common case.
+  const deltasBySeries = new Map(
+    series.filter((item) => item.deltas).map((item) => [item.name, item.deltas])
+  )
+
+  const getDelta = deltasBySeries.size
+    ? (seriesName: string, categoryIndex: number) =>
+        deltasBySeries.get(seriesName)?.[categoryIndex] ?? undefined
+    : undefined
+
   const categoryAxis = { type: 'category', data: categories }
   const valueAxis = { type: 'value' }
 
@@ -204,7 +233,10 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
       borderWidth: 0,
       padding: 0,
       extraCssText: 'box-shadow: none;',
-      formatter: createAxisTooltipFormatter({ reverse: reverseTooltipRows }),
+      formatter: createAxisTooltipFormatter({
+        reverse: reverseTooltipRows,
+        getDelta,
+      }),
       position: createTooltipPositioner(
         tokens.px(tooltipOffsetToken) ?? tooltipOffsetFallback
       ),

--- a/packages/charts/src/components/bar-chart/bar-option.ts
+++ b/packages/charts/src/components/bar-chart/bar-option.ts
@@ -95,10 +95,10 @@ export function collapseSeries(
 const radiusToken = '--sl-radius-1'
 const spaceSmall = '--sl-space-2'
 const spaceLegend = '--sl-space-10'
-// design-notes/tooltip.md, Positioning: 8px between the hovered bar and the tooltip
+// Design spec, positioning: 8px between the hovered bar and the tooltip
 const tooltipOffsetToken = '--sl-space-2'
 const tooltipOffsetFallback = 8
-// design-notes/bar-chart.md, Behaviour: hover overlay over the selected category
+// Design spec, behaviour: hover overlay over the selected category
 const hoverOverlayToken = '--sl-bg-muted-plain-hover'
 
 type BorderRadius = [number, number, number, number]

--- a/packages/charts/src/components/bar-chart/bar-option.ts
+++ b/packages/charts/src/components/bar-chart/bar-option.ts
@@ -192,6 +192,12 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
         type: 'shadow',
         shadowStyle: { color: tokens.get(hoverOverlayToken) },
       },
+      // The tooltip is allowed to overflow the chart. `confine` would push it
+      // back inside the chart bounds, and leaving the element inside the chart
+      // container lets any `overflow: hidden` ancestor clip it — so it renders
+      // on `body` instead, above whatever the chart sits in.
+      confine: false,
+      appendTo: 'body',
       // Visuals come entirely from the formatter's own markup + tooltip.css
       // (data-sl-chart-tooltip*), not from the engine's tooltip container.
       backgroundColor: 'transparent',

--- a/packages/charts/src/components/bar-chart/bar-option.ts
+++ b/packages/charts/src/components/bar-chart/bar-option.ts
@@ -197,17 +197,17 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
   // the first series where the reader starts.
   const reverseTooltipRows = direction === 'vertical' && grouping === 'stacked'
 
-  // Rows name their series, so that name is what a delta is looked up by —
-  // the same key the legend and tooltip already identify a series with. Left
-  // undefined when no series supplied deltas, so the tooltip skips the lookup
-  // entirely for the common case.
-  const deltasBySeries = new Map(
-    series.filter((item) => item.deltas).map((item) => [item.name, item.deltas])
-  )
+  // Deltas are looked up by the series' position, not its name: names are not
+  // required to be unique, and two series sharing one would otherwise both
+  // resolve to whichever came last. The collapsed list is exactly the order
+  // the engine receives its series in, so the index it reports lines up here.
+  // Left undefined when no series supplied deltas, so the tooltip skips the
+  // lookup entirely for the common case.
+  const deltasBySeries = series.map((item) => item.deltas)
 
-  const getDelta = deltasBySeries.size
-    ? (seriesName: string, categoryIndex: number) =>
-        deltasBySeries.get(seriesName)?.[categoryIndex] ?? undefined
+  const getDelta = deltasBySeries.some(Boolean)
+    ? (seriesIndex: number, categoryIndex: number) =>
+        deltasBySeries[seriesIndex]?.[categoryIndex] ?? undefined
     : undefined
 
   const categoryAxis = { type: 'category', data: categories }

--- a/packages/charts/src/components/bar-chart/bar-option.ts
+++ b/packages/charts/src/components/bar-chart/bar-option.ts
@@ -2,8 +2,8 @@ import type { EChartsCoreOption } from '../../internal/echarts'
 import type { ChartTokens } from '../../internal/theme'
 import { chartSeriesTokens } from '../../internal/theme'
 import {
+  createAxisTooltipFormatter,
   createTooltipPositioner,
-  formatAxisTooltip,
 } from '../../internal/tooltip'
 
 /**
@@ -174,6 +174,13 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
   const radius = tokens.px(radiusToken)
   const showLegend = series.length > 1
 
+  // A vertical stack piles the first series at the bottom, so its segments run
+  // last-to-first down the bar and the tooltip has to list them in reverse to
+  // read in the same order. No other geometry needs it: a horizontal stack
+  // grows left to right, and grouped bars sit side by side — both already put
+  // the first series where the reader starts.
+  const reverseTooltipRows = direction === 'vertical' && grouping === 'stacked'
+
   const categoryAxis = { type: 'category', data: categories }
   const valueAxis = { type: 'value' }
 
@@ -191,7 +198,7 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
       borderWidth: 0,
       padding: 0,
       extraCssText: 'box-shadow: none;',
-      formatter: formatAxisTooltip,
+      formatter: createAxisTooltipFormatter({ reverse: reverseTooltipRows }),
       position: createTooltipPositioner(
         tokens.px(tooltipOffsetToken) ?? tooltipOffsetFallback
       ),

--- a/packages/charts/src/components/bar-chart/bar-option.ts
+++ b/packages/charts/src/components/bar-chart/bar-option.ts
@@ -1,6 +1,10 @@
 import type { EChartsCoreOption } from '../../internal/echarts'
 import type { ChartTokens } from '../../internal/theme'
 import { chartSeriesTokens } from '../../internal/theme'
+import {
+  createTooltipPositioner,
+  formatAxisTooltip,
+} from '../../internal/tooltip'
 
 /**
  * A single bar series.
@@ -91,6 +95,11 @@ export function collapseSeries(
 const radiusToken = '--sl-radius-1'
 const spaceSmall = '--sl-space-2'
 const spaceLegend = '--sl-space-10'
+// design-notes/tooltip.md, Positioning: 8px between the hovered bar and the tooltip
+const tooltipOffsetToken = '--sl-space-2'
+const tooltipOffsetFallback = 8
+// design-notes/bar-chart.md, Behaviour: hover overlay over the selected category
+const hoverOverlayToken = '--sl-bg-muted-plain-hover'
 
 type BorderRadius = [number, number, number, number]
 
@@ -172,7 +181,20 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
     legend: { show: showLegend, left: 0, bottom: 0 },
     tooltip: {
       trigger: 'axis',
-      axisPointer: { type: 'shadow' },
+      axisPointer: {
+        type: 'shadow',
+        shadowStyle: { color: tokens.get(hoverOverlayToken) },
+      },
+      // Visuals come entirely from the formatter's own markup + tooltip.css
+      // (data-sl-chart-tooltip*), not from the engine's tooltip container.
+      backgroundColor: 'transparent',
+      borderWidth: 0,
+      padding: 0,
+      extraCssText: 'box-shadow: none;',
+      formatter: formatAxisTooltip,
+      position: createTooltipPositioner(
+        tokens.px(tooltipOffsetToken) ?? tooltipOffsetFallback
+      ),
     },
     grid: {
       containLabel: true,

--- a/packages/charts/src/components/bar-chart/stories/examples.stories.tsx
+++ b/packages/charts/src/components/bar-chart/stories/examples.stories.tsx
@@ -1,5 +1,6 @@
 import { LocaleProvider } from '@vtex/shoreline'
 
+import type { ChartTooltipDelta } from '../../../index'
 import { BarChart } from '../index'
 import '../../../styles.css'
 
@@ -35,6 +36,108 @@ export function MultiSeries() {
         { name: 'Revenue', data: revenue },
         { name: 'Cost', data: cost },
         { name: 'Profit', data: profit },
+      ]}
+    />
+  )
+}
+
+const previousRevenue = [3900, 5300, 4800, 5500, 6100, 6400]
+const complaints = [180, 140, 155, 120, 95, 70]
+const previousComplaints = [160, 175, 130, 145, 130, 90]
+
+/**
+ * Formats one period-over-period change the way a consumer would: the value
+ * carries whatever unit they want, `direction` follows the actual movement,
+ * and `tone` says what that movement means — which is why the caller passes
+ * `goodWhen` instead of it being inferred from the sign.
+ */
+function percentChange(
+  current: number[],
+  previous: number[],
+  goodWhen: 'up' | 'down'
+): Array<ChartTooltipDelta | null> {
+  return current.map((value, index) => {
+    const before = previous[index]
+
+    // No comparable figure for this category, so its row shows no delta.
+    if (before === undefined || before === 0) return null
+
+    const change = ((value - before) / before) * 100
+
+    if (change === 0) return { value: '0.0%', direction: 'flat' }
+
+    const direction = change > 0 ? 'up' : 'down'
+
+    return {
+      value: `${Math.abs(change).toFixed(1)}%`,
+      direction,
+      tone: direction === goodWhen ? 'success' : 'critical',
+    }
+  })
+}
+
+/**
+ * Hover a bar: each tooltip row carries the change against the previous
+ * period. The comparison data need not be plotted — `previousRevenue` is
+ * nowhere on the chart, it only feeds `deltas`.
+ */
+export function WithDeltas() {
+  return (
+    <BarChart
+      label="Revenue by month, compared with the previous period"
+      categories={months}
+      series={[
+        {
+          name: 'Revenue',
+          data: revenue,
+          deltas: percentChange(revenue, previousRevenue, 'up'),
+        },
+      ]}
+    />
+  )
+}
+
+/**
+ * `direction` and `tone` are independent, so the same downward arrow can read
+ * either way: revenue falling is critical, complaints falling is a success.
+ * Only the consumer knows which, so neither is derived from the sign.
+ */
+export function DeltaToneIsTheConsumers() {
+  return (
+    <BarChart
+      label="Revenue and complaints by month, compared with the previous period"
+      categories={months}
+      series={[
+        {
+          name: 'Revenue',
+          data: revenue,
+          deltas: percentChange(revenue, previousRevenue, 'up'),
+        },
+        {
+          name: 'Complaints',
+          data: complaints,
+          deltas: percentChange(complaints, previousComplaints, 'down'),
+        },
+      ]}
+    />
+  )
+}
+
+/**
+ * Deltas are per category and optional: only the first three months have a
+ * comparable figure here, so the rest of the tooltips show plain values.
+ */
+export function PartialDeltas() {
+  return (
+    <BarChart
+      label="Revenue by month, compared where data exists"
+      categories={months}
+      series={[
+        {
+          name: 'Revenue',
+          data: revenue,
+          deltas: percentChange(revenue, previousRevenue.slice(0, 3), 'up'),
+        },
       ]}
     />
   )

--- a/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
+++ b/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
@@ -24,6 +24,8 @@ function build(overrides: Partial<BuildBarOptionArgs> = {}) {
     tooltip: {
       trigger: string
       axisPointer: { type: string }
+      confine: boolean
+      appendTo: string
       backgroundColor: string
       formatter: (params: unknown) => string
       position: unknown
@@ -299,6 +301,13 @@ describe('buildBarOption', () => {
     expect(option.tooltip.backgroundColor).toBe('transparent')
     expect(typeof option.tooltip.formatter).toBe('function')
     expect(typeof option.tooltip.position).toBe('function')
+  })
+
+  test('lets the tooltip overflow the chart instead of being confined to it', () => {
+    const option = build()
+
+    expect(option.tooltip.confine).toBe(false)
+    expect(option.tooltip.appendTo).toBe('body')
   })
 
   test('lists tooltip rows top-down for a vertical stack', () => {

--- a/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
+++ b/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
@@ -21,6 +21,13 @@ function build(overrides: Partial<BuildBarOptionArgs> = {}) {
     ...overrides,
   }) as {
     legend: { show: boolean }
+    tooltip: {
+      trigger: string
+      axisPointer: { type: string }
+      backgroundColor: string
+      formatter: unknown
+      position: unknown
+    }
     xAxis: { type: string; data?: string[] }
     yAxis: { type: string; data?: string[] }
     series: Array<{
@@ -275,6 +282,16 @@ describe('buildBarOption', () => {
     // The aggregate is last in the collapsed list, so it owns the rounding.
     expect(radiusAt(option, 1, 0)).toEqual([0, 0, 0, 0])
     expect(radiusAt(option, 2, 0)).toEqual([4, 4, 0, 0])
+  })
+
+  test('configures an axis-trigger tooltip with a DOM formatter and position function', () => {
+    const option = build()
+
+    expect(option.tooltip.trigger).toBe('axis')
+    expect(option.tooltip.axisPointer.type).toBe('shadow')
+    expect(option.tooltip.backgroundColor).toBe('transparent')
+    expect(typeof option.tooltip.formatter).toBe('function')
+    expect(typeof option.tooltip.position).toBe('function')
   })
 
   test('skips rounding for null, zero, and unresolvable radius', () => {

--- a/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
+++ b/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
@@ -345,6 +345,96 @@ describe('buildBarOption', () => {
     }
   })
 
+  test('shows a series delta at the hovered category', () => {
+    const option = build({
+      series: [
+        {
+          name: 'Website',
+          data: [10, 20],
+          deltas: [
+            { value: '12%', direction: 'up', tone: 'success' },
+            { value: '4%', direction: 'down', tone: 'critical' },
+          ],
+        },
+      ],
+    })
+
+    const first = option.tooltip.formatter([
+      { name: 'Jan', seriesName: 'Website', value: 10, dataIndex: 0 },
+    ])
+
+    const second = option.tooltip.formatter([
+      { name: 'Feb', seriesName: 'Website', value: 20, dataIndex: 1 },
+    ])
+
+    expect(first).toContain('12%')
+    expect(first).toContain('data-tone="success"')
+    expect(second).toContain('4%')
+    expect(second).toContain('data-tone="critical"')
+  })
+
+  test('leaves a category without a delta plain', () => {
+    const option = build({
+      series: [
+        {
+          name: 'Website',
+          data: [10, 20],
+          deltas: [null, { value: '4%', direction: 'up' }],
+        },
+      ],
+    })
+
+    const html = option.tooltip.formatter([
+      { name: 'Jan', seriesName: 'Website', value: 10, dataIndex: 0 },
+    ])
+
+    expect(html).not.toContain('data-sl-chart-tooltip-row-delta')
+  })
+
+  test('resolves each series delta independently of the others', () => {
+    const option = build({
+      series: [
+        {
+          name: 'Website',
+          data: [10],
+          deltas: [{ value: '12%', direction: 'up' }],
+        },
+        { name: 'Marketplace', data: [20] },
+      ],
+    })
+
+    const html = option.tooltip.formatter([
+      { name: 'Jan', seriesName: 'Website', value: 10, dataIndex: 0 },
+      { name: 'Jan', seriesName: 'Marketplace', value: 20, dataIndex: 0 },
+    ])
+
+    expect(html.match(/data-sl-chart-tooltip-row-delta[ >]/g)).toHaveLength(1)
+    expect(html).toContain('12%')
+  })
+
+  test('drops deltas for the series folded into the aggregate', () => {
+    const delta = { value: '12%', direction: 'up' as const }
+
+    const option = build({
+      series: [
+        { name: 'A', data: [10], deltas: [delta] },
+        { name: 'B', data: [20], deltas: [delta] },
+        { name: 'C', data: [30], deltas: [delta] },
+        { name: 'D', data: [40], deltas: [delta] },
+      ],
+    })
+
+    // A and B keep their slots; C and D fold into "Others", which cannot carry
+    // a delta because the ones it replaces are already formatted.
+    const html = option.tooltip.formatter([
+      { name: 'Jan', seriesName: 'A', value: 10, dataIndex: 0 },
+      { name: 'Jan', seriesName: 'Others', value: 70, dataIndex: 0 },
+    ])
+
+    expect(html).toContain('12%')
+    expect(html.match(/data-sl-chart-tooltip-row-delta[ >]/g)).toHaveLength(1)
+  })
+
   test('skips rounding for null, zero, and unresolvable radius', () => {
     const option = build({ series: [{ name: 'A', data: [null, 0] }] })
 

--- a/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
+++ b/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
@@ -25,7 +25,7 @@ function build(overrides: Partial<BuildBarOptionArgs> = {}) {
       trigger: string
       axisPointer: { type: string }
       backgroundColor: string
-      formatter: unknown
+      formatter: (params: unknown) => string
       position: unknown
     }
     xAxis: { type: string; data?: string[] }
@@ -40,6 +40,13 @@ function build(overrides: Partial<BuildBarOptionArgs> = {}) {
     }>
   }
 }
+
+// What the engine passes the tooltip formatter on hover: one item per series
+// at the hovered category, always in series order.
+const hoveredParams = [
+  { name: 'Jan', seriesName: 'Website', value: 10, color: '#3993f4' },
+  { name: 'Jan', seriesName: 'Marketplace', value: 20, color: '#9c56f3' },
+]
 
 function radiusAt(
   option: ReturnType<typeof build>,
@@ -292,6 +299,41 @@ describe('buildBarOption', () => {
     expect(option.tooltip.backgroundColor).toBe('transparent')
     expect(typeof option.tooltip.formatter).toBe('function')
     expect(typeof option.tooltip.position).toBe('function')
+  })
+
+  test('lists tooltip rows top-down for a vertical stack', () => {
+    const option = build({
+      series: [
+        { name: 'Website', data: [10] },
+        { name: 'Marketplace', data: [20] },
+      ],
+      direction: 'vertical',
+      grouping: 'stacked',
+    })
+
+    const html = option.tooltip.formatter(hoveredParams)
+
+    // Marketplace stacks on top of Website, so it heads the tooltip.
+    expect(html.indexOf('Marketplace')).toBeLessThan(html.indexOf('Website'))
+  })
+
+  test('keeps series order for a horizontal stack and for grouped bars', () => {
+    const series = [
+      { name: 'Website', data: [10] },
+      { name: 'Marketplace', data: [20] },
+    ]
+
+    for (const overrides of [
+      { direction: 'horizontal', grouping: 'stacked' },
+      { direction: 'vertical', grouping: 'grouped' },
+      { direction: 'horizontal', grouping: 'grouped' },
+    ] as const) {
+      const html = build({ series, ...overrides }).tooltip.formatter(
+        hoveredParams
+      )
+
+      expect(html.indexOf('Website')).toBeLessThan(html.indexOf('Marketplace'))
+    }
   })
 
   test('skips rounding for null, zero, and unresolvable radius', () => {

--- a/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
+++ b/packages/charts/src/components/bar-chart/tests/bar-option.test.ts
@@ -360,11 +360,23 @@ describe('buildBarOption', () => {
     })
 
     const first = option.tooltip.formatter([
-      { name: 'Jan', seriesName: 'Website', value: 10, dataIndex: 0 },
+      {
+        name: 'Jan',
+        seriesName: 'Website',
+        value: 10,
+        seriesIndex: 0,
+        dataIndex: 0,
+      },
     ])
 
     const second = option.tooltip.formatter([
-      { name: 'Feb', seriesName: 'Website', value: 20, dataIndex: 1 },
+      {
+        name: 'Feb',
+        seriesName: 'Website',
+        value: 20,
+        seriesIndex: 0,
+        dataIndex: 1,
+      },
     ])
 
     expect(first).toContain('12%')
@@ -385,7 +397,13 @@ describe('buildBarOption', () => {
     })
 
     const html = option.tooltip.formatter([
-      { name: 'Jan', seriesName: 'Website', value: 10, dataIndex: 0 },
+      {
+        name: 'Jan',
+        seriesName: 'Website',
+        value: 10,
+        seriesIndex: 0,
+        dataIndex: 0,
+      },
     ])
 
     expect(html).not.toContain('data-sl-chart-tooltip-row-delta')
@@ -404,8 +422,20 @@ describe('buildBarOption', () => {
     })
 
     const html = option.tooltip.formatter([
-      { name: 'Jan', seriesName: 'Website', value: 10, dataIndex: 0 },
-      { name: 'Jan', seriesName: 'Marketplace', value: 20, dataIndex: 0 },
+      {
+        name: 'Jan',
+        seriesName: 'Website',
+        value: 10,
+        seriesIndex: 0,
+        dataIndex: 0,
+      },
+      {
+        name: 'Jan',
+        seriesName: 'Marketplace',
+        value: 20,
+        seriesIndex: 1,
+        dataIndex: 0,
+      },
     ])
 
     expect(html.match(/data-sl-chart-tooltip-row-delta[ >]/g)).toHaveLength(1)
@@ -427,12 +457,57 @@ describe('buildBarOption', () => {
     // A and B keep their slots; C and D fold into "Others", which cannot carry
     // a delta because the ones it replaces are already formatted.
     const html = option.tooltip.formatter([
-      { name: 'Jan', seriesName: 'A', value: 10, dataIndex: 0 },
-      { name: 'Jan', seriesName: 'Others', value: 70, dataIndex: 0 },
+      { name: 'Jan', seriesName: 'A', value: 10, seriesIndex: 0, dataIndex: 0 },
+      {
+        name: 'Jan',
+        seriesName: 'Others',
+        value: 70,
+        seriesIndex: 2,
+        dataIndex: 0,
+      },
     ])
 
     expect(html).toContain('12%')
     expect(html.match(/data-sl-chart-tooltip-row-delta[ >]/g)).toHaveLength(1)
+  })
+
+  test('keeps deltas apart for two series sharing a name', () => {
+    const option = build({
+      series: [
+        {
+          name: 'Sales',
+          data: [10],
+          deltas: [{ value: 'first', direction: 'up' }],
+        },
+        {
+          name: 'Sales',
+          data: [20],
+          deltas: [{ value: 'second', direction: 'up' }],
+        },
+      ],
+    })
+
+    const html = option.tooltip.formatter([
+      {
+        name: 'Jan',
+        seriesName: 'Sales',
+        value: 10,
+        seriesIndex: 0,
+        dataIndex: 0,
+      },
+      {
+        name: 'Jan',
+        seriesName: 'Sales',
+        value: 20,
+        seriesIndex: 1,
+        dataIndex: 0,
+      },
+    ])
+
+    // Positional lookup, so the second row is not served the first's delta.
+    expect(html).toContain('first')
+    expect(html).toContain('second')
+    expect(html.indexOf('first')).toBeLessThan(html.indexOf('second'))
   })
 
   test('skips rounding for null, zero, and unresolvable radius', () => {

--- a/packages/charts/src/index.ts
+++ b/packages/charts/src/index.ts
@@ -11,3 +11,7 @@ export type {
   BarChartProps,
   BarChartSeries,
 } from './components/bar-chart'
+// Consumers construct these to fill `BarChartSeries.deltas`, so the shape has
+// to be nameable outside the package even though the tooltip itself is
+// internal.
+export type { ChartTooltipDelta } from './internal/tooltip'

--- a/packages/charts/src/internal/theme/chart-theme.ts
+++ b/packages/charts/src/internal/theme/chart-theme.ts
@@ -41,7 +41,6 @@ const fontFamily = '--sl-font-family-sans'
 const fontSizeCaption = '--sl-font-size-1'
 const fgBase = '--sl-fg-base'
 const fgMuted = '--sl-fg-muted'
-const bgBase = '--sl-bg-base'
 // color component of --sl-border-base, which is a full border shorthand
 const lineColor = '--sl-color-gray-3'
 // legend symbols are square, so one token drives both of their dimensions
@@ -93,15 +92,9 @@ export function createChartTheme(tokens: ChartTokens) {
         fontSize: px(fontSizeCaption),
       },
     },
-    tooltip: {
-      backgroundColor: get(bgBase),
-      borderColor: get(lineColor),
-      textStyle: {
-        color: get(fgBase),
-        fontFamily: get(fontFamily),
-        fontSize: px(fontSizeCaption),
-      },
-    },
+    // No theme-level tooltip styling: every chart renders its tooltip
+    // through a custom `formatter` + `data-sl-chart-tooltip*` CSS (see
+    // internal/tooltip), which fully overrides whatever the theme sets here.
   }
 }
 

--- a/packages/charts/src/internal/tooltip/index.ts
+++ b/packages/charts/src/internal/tooltip/index.ts
@@ -6,8 +6,8 @@ export type {
   AxisTooltipItem,
   AxisTooltipOptions,
   ChartTooltipData,
+  ChartTooltipDelta,
   ChartTooltipRow,
-  ChartTooltipVariation,
 } from './tooltip-model'
 export { buildAxisTooltipData } from './tooltip-model'
 export { getTooltipPosition } from './tooltip-position'

--- a/packages/charts/src/internal/tooltip/index.ts
+++ b/packages/charts/src/internal/tooltip/index.ts
@@ -1,6 +1,10 @@
-export { createTooltipPositioner, formatAxisTooltip } from './tooltip-echarts'
+export {
+  createAxisTooltipFormatter,
+  createTooltipPositioner,
+} from './tooltip-echarts'
 export type {
   AxisTooltipItem,
+  AxisTooltipOptions,
   ChartTooltipData,
   ChartTooltipRow,
   ChartTooltipVariation,

--- a/packages/charts/src/internal/tooltip/index.ts
+++ b/packages/charts/src/internal/tooltip/index.ts
@@ -1,0 +1,11 @@
+export { createTooltipPositioner, formatAxisTooltip } from './tooltip-echarts'
+export type {
+  AxisTooltipItem,
+  ChartTooltipData,
+  ChartTooltipRow,
+  ChartTooltipVariation,
+} from './tooltip-model'
+export { buildAxisTooltipData } from './tooltip-model'
+export { getTooltipPosition } from './tooltip-position'
+export type { TooltipPositionInput } from './tooltip-position'
+export { renderChartTooltip } from './tooltip-render'

--- a/packages/charts/src/internal/tooltip/stories/tooltip.show.stories.tsx
+++ b/packages/charts/src/internal/tooltip/stories/tooltip.show.stories.tsx
@@ -1,0 +1,192 @@
+import type { ReactNode } from 'react'
+
+import type { ChartTooltipData } from '../tooltip-model'
+import { renderChartTooltip } from '../tooltip-render'
+import '../../../styles.css'
+
+export default {
+  title: 'charts/internal/chart-tooltip',
+  parameters: {
+    chromatic: { disableSnapshot: false },
+  },
+}
+
+// Matches the Figma "ChartTooltip" reference frames' swatch colors directly,
+// rather than resolved theme tokens — this story previews the row model in
+// isolation, not a real chart's token-bridged palette.
+const seriesColor = {
+  blue: '#3993f4',
+  purple: '#9c56f3',
+  orange: '#ffa138',
+  gray: '#858585',
+}
+
+/**
+ * Renders `renderChartTooltip`'s output exactly as the engine does: as a raw
+ * HTML string set on a plain element, not JSX (see ../tooltip-render.ts).
+ */
+function TooltipPreview(props: { data: ChartTooltipData }) {
+  return (
+    <div
+      style={{ display: 'inline-block' }}
+      dangerouslySetInnerHTML={{ __html: renderChartTooltip(props.data) }}
+    />
+  )
+}
+
+function Section(props: { label: string; children: ReactNode }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        gap: '1rem',
+        padding: '1rem 0',
+        borderTop: '1px solid #e0e0e0',
+      }}
+    >
+      <div style={{ width: '12rem', flexShrink: 0, fontSize: '0.75rem' }}>
+        {props.label}
+      </div>
+      <div style={{ display: 'flex', gap: '1rem', flexWrap: 'wrap' }}>
+        {props.children}
+      </div>
+    </div>
+  )
+}
+
+export function Show() {
+  return (
+    <div>
+      <Section label="Small (128px, no deltas)">
+        <TooltipPreview
+          data={{
+            title: 'Jun 05',
+            rows: [
+              { label: 'Label', value: '139', color: seriesColor.blue },
+              { label: 'Label', value: '143', color: seriesColor.purple },
+              { label: 'Label', value: '503', color: seriesColor.orange },
+            ],
+          }}
+        />
+      </Section>
+
+      <Section label="Max (268px, with deltas)">
+        <TooltipPreview
+          data={{
+            title: 'Title',
+            rows: [
+              {
+                label: 'Label',
+                value: 'R$ 288.052.925,34',
+                color: seriesColor.blue,
+                variation: {
+                  value: '00,00%',
+                  direction: 'up',
+                  tone: 'success',
+                },
+              },
+              {
+                label: 'Label',
+                value: '000',
+                color: seriesColor.purple,
+                variation: { value: '0,00%', direction: 'up' },
+              },
+              {
+                label: 'Label',
+                value: '000',
+                color: seriesColor.orange,
+                variation: { value: '0,00%', direction: 'up' },
+              },
+              {
+                label: 'Label',
+                value: '000',
+                color: seriesColor.gray,
+                variation: { value: '0,00%', direction: 'up' },
+              },
+            ],
+          }}
+        />
+      </Section>
+
+      <Section label="Variation directions and tones">
+        <TooltipPreview
+          data={{
+            rows: [
+              {
+                label: 'Up / success',
+                value: '139',
+                color: seriesColor.blue,
+                variation: {
+                  value: '12.4%',
+                  direction: 'up',
+                  tone: 'success',
+                },
+              },
+            ],
+          }}
+        />
+        <TooltipPreview
+          data={{
+            rows: [
+              {
+                label: 'Down / critical',
+                value: '139',
+                color: seriesColor.blue,
+                variation: {
+                  value: '8.1%',
+                  direction: 'down',
+                  tone: 'critical',
+                },
+              },
+            ],
+          }}
+        />
+        <TooltipPreview
+          data={{
+            rows: [
+              {
+                label: 'Flat / neutral',
+                value: '139',
+                color: seriesColor.blue,
+                variation: { value: '0%', direction: 'flat' },
+              },
+            ],
+          }}
+        />
+      </Section>
+
+      <Section label="No title">
+        <TooltipPreview
+          data={{
+            rows: [{ label: 'Revenue', value: '139', color: seriesColor.blue }],
+          }}
+        />
+      </Section>
+
+      <Section label="Row without a color swatch">
+        <TooltipPreview
+          data={{
+            title: 'Jan',
+            rows: [{ label: 'Revenue', value: '139' }],
+          }}
+        />
+      </Section>
+
+      <Section label="Long label and value (min/max width)">
+        <TooltipPreview
+          data={{
+            title: 'A long category name that could wrap',
+            rows: [
+              {
+                label: 'A fairly long series label',
+                value: '1,234,567,890',
+                color: seriesColor.blue,
+              },
+            ],
+          }}
+        />
+      </Section>
+    </div>
+  )
+}

--- a/packages/charts/src/internal/tooltip/stories/tooltip.show.stories.tsx
+++ b/packages/charts/src/internal/tooltip/stories/tooltip.show.stories.tsx
@@ -80,7 +80,7 @@ export function Show() {
                 label: 'Label',
                 value: 'R$ 288.052.925,34',
                 color: seriesColor.blue,
-                variation: {
+                delta: {
                   value: '00,00%',
                   direction: 'up',
                   tone: 'success',
@@ -90,26 +90,26 @@ export function Show() {
                 label: 'Label',
                 value: '000',
                 color: seriesColor.purple,
-                variation: { value: '0,00%', direction: 'up' },
+                delta: { value: '0,00%', direction: 'up' },
               },
               {
                 label: 'Label',
                 value: '000',
                 color: seriesColor.orange,
-                variation: { value: '0,00%', direction: 'up' },
+                delta: { value: '0,00%', direction: 'up' },
               },
               {
                 label: 'Label',
                 value: '000',
                 color: seriesColor.gray,
-                variation: { value: '0,00%', direction: 'up' },
+                delta: { value: '0,00%', direction: 'up' },
               },
             ],
           }}
         />
       </Section>
 
-      <Section label="Variation directions and tones">
+      <Section label="Delta directions and tones">
         <TooltipPreview
           data={{
             rows: [
@@ -117,7 +117,7 @@ export function Show() {
                 label: 'Up / success',
                 value: '139',
                 color: seriesColor.blue,
-                variation: {
+                delta: {
                   value: '12.4%',
                   direction: 'up',
                   tone: 'success',
@@ -133,7 +133,7 @@ export function Show() {
                 label: 'Down / critical',
                 value: '139',
                 color: seriesColor.blue,
-                variation: {
+                delta: {
                   value: '8.1%',
                   direction: 'down',
                   tone: 'critical',
@@ -149,7 +149,7 @@ export function Show() {
                 label: 'Flat / neutral',
                 value: '139',
                 color: seriesColor.blue,
-                variation: { value: '0%', direction: 'flat' },
+                delta: { value: '0%', direction: 'flat' },
               },
             ],
           }}

--- a/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
@@ -45,10 +45,10 @@ describe('createAxisTooltipFormatter', () => {
     expect(html.indexOf('Costs')).toBeLessThan(html.indexOf('Revenue'))
   })
 
-  test('passes the engine dataIndex through to the delta resolver', () => {
+  test('passes the engine series and data indexes to the delta resolver', () => {
     const html = createAxisTooltipFormatter({
-      getDelta: (seriesName, dataIndex) => ({
-        value: `${seriesName}@${dataIndex}`,
+      getDelta: (seriesIndex, dataIndex) => ({
+        value: `${seriesIndex}:${dataIndex}`,
         direction: 'up',
       }),
     })([
@@ -57,14 +57,15 @@ describe('createAxisTooltipFormatter', () => {
         seriesName: 'Revenue',
         value: 10,
         color: '#3993f4',
+        seriesIndex: 3,
         dataIndex: 1,
       },
     ])
 
-    expect(html).toContain('Revenue@1')
+    expect(html).toContain('3:1')
   })
 
-  test('resolves no delta when the engine reports no dataIndex', () => {
+  test('resolves no delta when the engine reports no positions', () => {
     const html = createAxisTooltipFormatter({
       getDelta: () => ({ value: '12%', direction: 'up' as const }),
     })([{ name: 'Jan', seriesName: 'Revenue', value: 10, color: '#3993f4' }])

--- a/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from 'vitest'
 
-import { createTooltipPositioner, formatAxisTooltip } from '../tooltip-echarts'
+import {
+  createAxisTooltipFormatter,
+  createTooltipPositioner,
+} from '../tooltip-echarts'
 
-describe('formatAxisTooltip', () => {
+describe('createAxisTooltipFormatter', () => {
   test('wraps a single item param in an array', () => {
-    const html = formatAxisTooltip({
+    const html = createAxisTooltipFormatter()({
       name: 'Jan',
       seriesName: 'Revenue',
       value: 10,
@@ -15,7 +18,7 @@ describe('formatAxisTooltip', () => {
   })
 
   test('renders one row per series in an axis-trigger array', () => {
-    const html = formatAxisTooltip([
+    const html = createAxisTooltipFormatter()([
       { name: 'Jan', seriesName: 'Revenue', value: 10, color: '#3993f4' },
       { name: 'Jan', seriesName: 'Costs', value: 4, color: '#9c56f3' },
     ])
@@ -24,8 +27,26 @@ describe('formatAxisTooltip', () => {
     expect(html).toContain('Costs')
   })
 
+  test('keeps the engine series order by default', () => {
+    const html = createAxisTooltipFormatter()([
+      { name: 'Jan', seriesName: 'Revenue', value: 10, color: '#3993f4' },
+      { name: 'Jan', seriesName: 'Costs', value: 4, color: '#9c56f3' },
+    ])
+
+    expect(html.indexOf('Revenue')).toBeLessThan(html.indexOf('Costs'))
+  })
+
+  test('reverses the rows when bound to reverse order', () => {
+    const html = createAxisTooltipFormatter({ reverse: true })([
+      { name: 'Jan', seriesName: 'Revenue', value: 10, color: '#3993f4' },
+      { name: 'Jan', seriesName: 'Costs', value: 4, color: '#9c56f3' },
+    ])
+
+    expect(html.indexOf('Costs')).toBeLessThan(html.indexOf('Revenue'))
+  })
+
   test('ignores non-numeric values and non-string colors from the engine', () => {
-    const html = formatAxisTooltip([
+    const html = createAxisTooltipFormatter()([
       { name: 'Jan', seriesName: 'Revenue', value: '-', color: {} },
     ])
 

--- a/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
@@ -45,6 +45,33 @@ describe('createAxisTooltipFormatter', () => {
     expect(html.indexOf('Costs')).toBeLessThan(html.indexOf('Revenue'))
   })
 
+  test('passes the engine dataIndex through to the delta resolver', () => {
+    const html = createAxisTooltipFormatter({
+      getDelta: (seriesName, dataIndex) => ({
+        value: `${seriesName}@${dataIndex}`,
+        direction: 'up',
+      }),
+    })([
+      {
+        name: 'Feb',
+        seriesName: 'Revenue',
+        value: 10,
+        color: '#3993f4',
+        dataIndex: 1,
+      },
+    ])
+
+    expect(html).toContain('Revenue@1')
+  })
+
+  test('resolves no delta when the engine reports no dataIndex', () => {
+    const html = createAxisTooltipFormatter({
+      getDelta: () => ({ value: '12%', direction: 'up' as const }),
+    })([{ name: 'Jan', seriesName: 'Revenue', value: 10, color: '#3993f4' }])
+
+    expect(html).not.toContain('12%')
+  })
+
   test('ignores non-numeric values and non-string colors from the engine', () => {
     const html = createAxisTooltipFormatter()([
       { name: 'Jan', seriesName: 'Revenue', value: '-', color: {} },

--- a/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-echarts.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'vitest'
+
+import { createTooltipPositioner, formatAxisTooltip } from '../tooltip-echarts'
+
+describe('formatAxisTooltip', () => {
+  test('wraps a single item param in an array', () => {
+    const html = formatAxisTooltip({
+      name: 'Jan',
+      seriesName: 'Revenue',
+      value: 10,
+      color: '#3993f4',
+    })
+
+    expect(html).toContain('Revenue')
+  })
+
+  test('renders one row per series in an axis-trigger array', () => {
+    const html = formatAxisTooltip([
+      { name: 'Jan', seriesName: 'Revenue', value: 10, color: '#3993f4' },
+      { name: 'Jan', seriesName: 'Costs', value: 4, color: '#9c56f3' },
+    ])
+
+    expect(html).toContain('Revenue')
+    expect(html).toContain('Costs')
+  })
+
+  test('ignores non-numeric values and non-string colors from the engine', () => {
+    const html = formatAxisTooltip([
+      { name: 'Jan', seriesName: 'Revenue', value: '-', color: {} },
+    ])
+
+    expect(html).toBe('')
+  })
+})
+
+describe('createTooltipPositioner', () => {
+  test('delegates to getTooltipPosition with the given offset', () => {
+    const position = createTooltipPositioner(8)
+
+    const result = position([100, 50], {}, null, null, {
+      contentSize: [80, 40],
+      viewSize: [400, 300],
+    })
+
+    expect(result).toEqual([108, 30])
+  })
+})

--- a/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 
 import { buildAxisTooltipData } from '../tooltip-model'
 
@@ -68,5 +68,59 @@ describe('buildAxisTooltipData', () => {
     )
 
     expect(data.rows.map((row) => row.label)).toEqual(['Other', 'Revenue'])
+  })
+
+  test('attaches a delta resolved from the series name and category', () => {
+    const data = buildAxisTooltipData(
+      [{ name: 'Feb', seriesName: 'Revenue', value: 10, dataIndex: 1 }],
+      {
+        getDelta: (seriesName, dataIndex) =>
+          seriesName === 'Revenue' && dataIndex === 1
+            ? { value: '12%', direction: 'up' }
+            : undefined,
+      }
+    )
+
+    expect(data.rows[0]?.delta).toEqual({ value: '12%', direction: 'up' })
+  })
+
+  test('leaves rows without a delta when the resolver has none', () => {
+    const data = buildAxisTooltipData(
+      [{ name: 'Jan', seriesName: 'Revenue', value: 10, dataIndex: 0 }],
+      { getDelta: () => undefined }
+    )
+
+    expect(data.rows[0]).not.toHaveProperty('delta')
+  })
+
+  test('skips the lookup for items carrying no category index', () => {
+    const getDelta = vi.fn()
+
+    buildAxisTooltipData([{ name: 'Jan', seriesName: 'Revenue', value: 10 }], {
+      getDelta,
+    })
+
+    expect(getDelta).not.toHaveBeenCalled()
+  })
+
+  test('keeps each delta with its own row when reversing', () => {
+    const data = buildAxisTooltipData(
+      [
+        { name: 'Jan', seriesName: 'Revenue', value: 10, dataIndex: 0 },
+        { name: 'Jan', seriesName: 'Costs', value: 4, dataIndex: 0 },
+      ],
+      {
+        reverse: true,
+        getDelta: (seriesName) => ({
+          value: seriesName === 'Revenue' ? '12%' : '3%',
+          direction: 'up',
+        }),
+      }
+    )
+
+    expect(data.rows.map((row) => [row.label, row.delta?.value])).toEqual([
+      ['Costs', '3%'],
+      ['Revenue', '12%'],
+    ])
   })
 })

--- a/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
@@ -43,4 +43,30 @@ describe('buildAxisTooltipData', () => {
   test('has no title when there are no items', () => {
     expect(buildAxisTooltipData([]).title).toBeUndefined()
   })
+
+  test('reverses row order on request, keeping the title', () => {
+    const data = buildAxisTooltipData(
+      [
+        { name: 'Jan', seriesName: 'Revenue', value: 10 },
+        { name: 'Jan', seriesName: 'Costs', value: 4 },
+      ],
+      { reverse: true }
+    )
+
+    expect(data.rows.map((row) => row.label)).toEqual(['Costs', 'Revenue'])
+    expect(data.title).toBe('Jan')
+  })
+
+  test('reverses only the rows that survive filtering', () => {
+    const data = buildAxisTooltipData(
+      [
+        { name: 'Jan', seriesName: 'Revenue', value: 10 },
+        { name: 'Jan', seriesName: 'Costs', value: null },
+        { name: 'Jan', seriesName: 'Other', value: 7 },
+      ],
+      { reverse: true }
+    )
+
+    expect(data.rows.map((row) => row.label)).toEqual(['Other', 'Revenue'])
+  })
 })

--- a/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
@@ -70,12 +70,20 @@ describe('buildAxisTooltipData', () => {
     expect(data.rows.map((row) => row.label)).toEqual(['Other', 'Revenue'])
   })
 
-  test('attaches a delta resolved from the series name and category', () => {
+  test('attaches a delta resolved from the series and category positions', () => {
     const data = buildAxisTooltipData(
-      [{ name: 'Feb', seriesName: 'Revenue', value: 10, dataIndex: 1 }],
+      [
+        {
+          name: 'Feb',
+          seriesName: 'Revenue',
+          value: 10,
+          seriesIndex: 2,
+          dataIndex: 1,
+        },
+      ],
       {
-        getDelta: (seriesName, dataIndex) =>
-          seriesName === 'Revenue' && dataIndex === 1
+        getDelta: (seriesIndex, dataIndex) =>
+          seriesIndex === 2 && dataIndex === 1
             ? { value: '12%', direction: 'up' }
             : undefined,
       }
@@ -86,33 +94,87 @@ describe('buildAxisTooltipData', () => {
 
   test('leaves rows without a delta when the resolver has none', () => {
     const data = buildAxisTooltipData(
-      [{ name: 'Jan', seriesName: 'Revenue', value: 10, dataIndex: 0 }],
+      [
+        {
+          name: 'Jan',
+          seriesName: 'Revenue',
+          value: 10,
+          seriesIndex: 0,
+          dataIndex: 0,
+        },
+      ],
       { getDelta: () => undefined }
     )
 
     expect(data.rows[0]).not.toHaveProperty('delta')
   })
 
-  test('skips the lookup for items carrying no category index', () => {
+  test('skips the lookup for items missing either position', () => {
     const getDelta = vi.fn()
 
-    buildAxisTooltipData([{ name: 'Jan', seriesName: 'Revenue', value: 10 }], {
-      getDelta,
-    })
+    buildAxisTooltipData(
+      [
+        { name: 'Jan', seriesName: 'A', value: 10 },
+        { name: 'Jan', seriesName: 'B', value: 10, seriesIndex: 1 },
+        { name: 'Jan', seriesName: 'C', value: 10, dataIndex: 0 },
+      ],
+      { getDelta }
+    )
 
     expect(getDelta).not.toHaveBeenCalled()
+  })
+
+  test('resolves same-named series to their own deltas', () => {
+    const data = buildAxisTooltipData(
+      [
+        {
+          name: 'Jan',
+          seriesName: 'Sales',
+          value: 10,
+          seriesIndex: 0,
+          dataIndex: 0,
+        },
+        {
+          name: 'Jan',
+          seriesName: 'Sales',
+          value: 20,
+          seriesIndex: 1,
+          dataIndex: 0,
+        },
+      ],
+      {
+        getDelta: (seriesIndex) => ({
+          value: `s${seriesIndex}`,
+          direction: 'up',
+        }),
+      }
+    )
+
+    expect(data.rows.map((row) => row.delta?.value)).toEqual(['s0', 's1'])
   })
 
   test('keeps each delta with its own row when reversing', () => {
     const data = buildAxisTooltipData(
       [
-        { name: 'Jan', seriesName: 'Revenue', value: 10, dataIndex: 0 },
-        { name: 'Jan', seriesName: 'Costs', value: 4, dataIndex: 0 },
+        {
+          name: 'Jan',
+          seriesName: 'Revenue',
+          value: 10,
+          seriesIndex: 0,
+          dataIndex: 0,
+        },
+        {
+          name: 'Jan',
+          seriesName: 'Costs',
+          value: 4,
+          seriesIndex: 1,
+          dataIndex: 0,
+        },
       ],
       {
         reverse: true,
-        getDelta: (seriesName) => ({
-          value: seriesName === 'Revenue' ? '12%' : '3%',
+        getDelta: (seriesIndex) => ({
+          value: seriesIndex === 0 ? '12%' : '3%',
           direction: 'up',
         }),
       }

--- a/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-model.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest'
+
+import { buildAxisTooltipData } from '../tooltip-model'
+
+describe('buildAxisTooltipData', () => {
+  test('uses the first item name as the title', () => {
+    const data = buildAxisTooltipData([
+      { name: 'Jan', seriesName: 'Revenue', value: 10 },
+    ])
+
+    expect(data.title).toBe('Jan')
+  })
+
+  test('maps each item to a row, keeping series color', () => {
+    const data = buildAxisTooltipData([
+      { name: 'Jan', seriesName: 'Revenue', value: 10, color: '#3993f4' },
+      { name: 'Jan', seriesName: 'Costs', value: 4, color: '#9c56f3' },
+    ])
+
+    expect(data.rows).toEqual([
+      { label: 'Revenue', value: '10', color: '#3993f4' },
+      { label: 'Costs', value: '4', color: '#9c56f3' },
+    ])
+  })
+
+  test('drops rows for series with no bar at this category', () => {
+    const data = buildAxisTooltipData([
+      { name: 'Jan', seriesName: 'Revenue', value: 10 },
+      { name: 'Jan', seriesName: 'Costs', value: null },
+      { name: 'Jan', seriesName: 'Other', value: undefined },
+    ])
+
+    expect(data.rows).toHaveLength(1)
+    expect(data.rows[0]?.label).toBe('Revenue')
+  })
+
+  test('falls back to an empty label when the series has none', () => {
+    const data = buildAxisTooltipData([{ name: 'Jan', value: 10 }])
+
+    expect(data.rows[0]?.label).toBe('')
+  })
+
+  test('has no title when there are no items', () => {
+    expect(buildAxisTooltipData([]).title).toBeUndefined()
+  })
+})

--- a/packages/charts/src/internal/tooltip/tests/tooltip-position.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-position.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'vitest'
+
+import { getTooltipPosition } from '../tooltip-position'
+
+describe('getTooltipPosition', () => {
+  test('places the tooltip to the right when the point is in the left half', () => {
+    const [x] = getTooltipPosition({
+      point: [100, 50],
+      contentSize: [80, 40],
+      viewSize: [400, 300],
+      offset: 8,
+    })
+
+    expect(x).toBe(108)
+  })
+
+  test('places the tooltip to the left when the point is in the right half', () => {
+    const [x] = getTooltipPosition({
+      point: [300, 50],
+      contentSize: [80, 40],
+      viewSize: [400, 300],
+      offset: 8,
+    })
+
+    expect(x).toBe(212)
+  })
+
+  test('centers the tooltip vertically on the point', () => {
+    const [, y] = getTooltipPosition({
+      point: [100, 150],
+      contentSize: [80, 40],
+      viewSize: [400, 300],
+      offset: 8,
+    })
+
+    expect(y).toBe(130)
+  })
+
+  test('clamps to the chart bounds at the near edge', () => {
+    const [x, y] = getTooltipPosition({
+      point: [0, 0],
+      contentSize: [80, 40],
+      viewSize: [400, 300],
+      offset: 8,
+    })
+
+    expect(x).toBe(8)
+    expect(y).toBe(0)
+  })
+
+  test('clamps to the chart bounds at the far edge', () => {
+    const [x] = getTooltipPosition({
+      point: [400, 0],
+      contentSize: [500, 40],
+      viewSize: [400, 300],
+      offset: 8,
+    })
+
+    expect(x).toBe(0)
+  })
+})

--- a/packages/charts/src/internal/tooltip/tests/tooltip-position.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-position.test.ts
@@ -36,26 +36,47 @@ describe('getTooltipPosition', () => {
     expect(y).toBe(130)
   })
 
-  test('clamps to the chart bounds at the near edge', () => {
-    const [x, y] = getTooltipPosition({
-      point: [0, 0],
+  test('overflows the top of the chart rather than clamping to it', () => {
+    const [, y] = getTooltipPosition({
+      point: [100, 0],
       contentSize: [80, 40],
       viewSize: [400, 300],
       offset: 8,
     })
 
-    expect(x).toBe(8)
-    expect(y).toBe(0)
+    expect(y).toBe(-20)
   })
 
-  test('clamps to the chart bounds at the far edge', () => {
+  test('overflows the bottom of the chart rather than clamping to it', () => {
+    const [, y] = getTooltipPosition({
+      point: [100, 300],
+      contentSize: [80, 40],
+      viewSize: [400, 300],
+      offset: 8,
+    })
+
+    expect(y).toBe(280)
+  })
+
+  test('overflows the left of the chart rather than clamping to it', () => {
     const [x] = getTooltipPosition({
-      point: [400, 0],
+      point: [300, 50],
       contentSize: [500, 40],
       viewSize: [400, 300],
       offset: 8,
     })
 
-    expect(x).toBe(0)
+    expect(x).toBe(-208)
+  })
+
+  test('overflows the right of the chart rather than clamping to it', () => {
+    const [x] = getTooltipPosition({
+      point: [199, 50],
+      contentSize: [500, 40],
+      viewSize: [400, 300],
+      offset: 8,
+    })
+
+    expect(x).toBe(207)
   })
 })

--- a/packages/charts/src/internal/tooltip/tests/tooltip-render.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-render.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest'
+
+import { renderChartTooltip } from '../tooltip-render'
+
+describe('renderChartTooltip', () => {
+  test('renders the title and one row per item', () => {
+    const html = renderChartTooltip({
+      title: 'Jan',
+      rows: [{ label: 'Revenue', value: '139', color: '#3993f4' }],
+    })
+
+    expect(html).toContain('data-sl-chart-tooltip-title')
+    expect(html).toContain('Jan')
+    expect(html).toContain('Revenue')
+    expect(html).toContain('139')
+    expect(html).toContain('background-color:#3993f4')
+  })
+
+  test('omits the title element when there is no title', () => {
+    const html = renderChartTooltip({
+      rows: [{ label: 'Revenue', value: '139' }],
+    })
+
+    expect(html).not.toContain('data-sl-chart-tooltip-title')
+  })
+
+  test('omits the line swatch when the row has no color', () => {
+    const html = renderChartTooltip({
+      rows: [{ label: 'Revenue', value: '139' }],
+    })
+
+    expect(html).not.toContain('data-sl-chart-tooltip-row-line')
+  })
+
+  test('renders nothing when there are no rows', () => {
+    expect(renderChartTooltip({ title: 'Jan', rows: [] })).toBe('')
+  })
+
+  test('escapes HTML in labels, values, and titles', () => {
+    const html = renderChartTooltip({
+      title: '<img>',
+      rows: [{ label: '<script>', value: '1 & 2' }],
+    })
+
+    expect(html).not.toContain('<script>')
+    expect(html).not.toContain('<img>')
+    expect(html).toContain('&lt;script&gt;')
+    expect(html).toContain('&lt;img&gt;')
+    expect(html).toContain('1 &amp; 2')
+  })
+
+  test('renders a variation with its direction and tone', () => {
+    const html = renderChartTooltip({
+      rows: [
+        {
+          label: 'Revenue',
+          value: '139',
+          variation: { value: '12%', direction: 'up', tone: 'success' },
+        },
+      ],
+    })
+
+    expect(html).toContain('data-direction="up"')
+    expect(html).toContain('data-tone="success"')
+    expect(html).toContain('<svg')
+  })
+
+  test('defaults variation tone to neutral', () => {
+    const html = renderChartTooltip({
+      rows: [
+        {
+          label: 'Revenue',
+          value: '139',
+          variation: { value: '0%', direction: 'up' },
+        },
+      ],
+    })
+
+    expect(html).toContain('data-tone="neutral"')
+  })
+
+  test('omits the arrow icon for a flat variation', () => {
+    const html = renderChartTooltip({
+      rows: [
+        {
+          label: 'Revenue',
+          value: '139',
+          variation: { value: '0%', direction: 'flat' },
+        },
+      ],
+    })
+
+    expect(html).not.toContain('<svg')
+  })
+})

--- a/packages/charts/src/internal/tooltip/tests/tooltip-render.test.ts
+++ b/packages/charts/src/internal/tooltip/tests/tooltip-render.test.ts
@@ -49,13 +49,13 @@ describe('renderChartTooltip', () => {
     expect(html).toContain('1 &amp; 2')
   })
 
-  test('renders a variation with its direction and tone', () => {
+  test('renders a delta with its direction and tone', () => {
     const html = renderChartTooltip({
       rows: [
         {
           label: 'Revenue',
           value: '139',
-          variation: { value: '12%', direction: 'up', tone: 'success' },
+          delta: { value: '12%', direction: 'up', tone: 'success' },
         },
       ],
     })
@@ -65,13 +65,13 @@ describe('renderChartTooltip', () => {
     expect(html).toContain('<svg')
   })
 
-  test('defaults variation tone to neutral', () => {
+  test('defaults delta tone to neutral', () => {
     const html = renderChartTooltip({
       rows: [
         {
           label: 'Revenue',
           value: '139',
-          variation: { value: '0%', direction: 'up' },
+          delta: { value: '0%', direction: 'up' },
         },
       ],
     })
@@ -79,13 +79,13 @@ describe('renderChartTooltip', () => {
     expect(html).toContain('data-tone="neutral"')
   })
 
-  test('omits the arrow icon for a flat variation', () => {
+  test('omits the arrow icon for a flat delta', () => {
     const html = renderChartTooltip({
       rows: [
         {
           label: 'Revenue',
           value: '139',
-          variation: { value: '0%', direction: 'flat' },
+          delta: { value: '0%', direction: 'flat' },
         },
       ],
     })

--- a/packages/charts/src/internal/tooltip/tooltip-echarts.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-echarts.ts
@@ -1,3 +1,4 @@
+import type { AxisTooltipOptions } from './tooltip-model'
 import { buildAxisTooltipData } from './tooltip-model'
 import { getTooltipPosition } from './tooltip-position'
 import { renderChartTooltip } from './tooltip-render'
@@ -20,25 +21,29 @@ interface EChartsTooltipPositionSize {
 }
 
 /**
- * Engine tooltip `formatter` for an axis-trigger tooltip: one row per series
- * at the hovered category, per the design spec's "tooltip shows data for the
- * selected bars" behaviour.
+ * Builds an engine tooltip `formatter` for an axis-trigger tooltip: one row
+ * per series at the hovered category, per the design spec's "tooltip shows
+ * data for the selected bars" behaviour. Bound to the row order the calling
+ * chart's geometry calls for — see `AxisTooltipOptions.reverse`.
  */
-export function formatAxisTooltip(
-  params: EChartsAxisTooltipParam | EChartsAxisTooltipParam[]
-): string {
-  const items = Array.isArray(params) ? params : [params]
+export function createAxisTooltipFormatter(options: AxisTooltipOptions = {}) {
+  return (
+    params: EChartsAxisTooltipParam | EChartsAxisTooltipParam[]
+  ): string => {
+    const items = Array.isArray(params) ? params : [params]
 
-  return renderChartTooltip(
-    buildAxisTooltipData(
-      items.map((item) => ({
-        name: item.name,
-        seriesName: item.seriesName,
-        value: typeof item.value === 'number' ? item.value : null,
-        color: typeof item.color === 'string' ? item.color : undefined,
-      }))
+    return renderChartTooltip(
+      buildAxisTooltipData(
+        items.map((item) => ({
+          name: item.name,
+          seriesName: item.seriesName,
+          value: typeof item.value === 'number' ? item.value : null,
+          color: typeof item.color === 'string' ? item.color : undefined,
+        })),
+        options
+      )
     )
-  )
+  }
 }
 
 /**

--- a/packages/charts/src/internal/tooltip/tooltip-echarts.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-echarts.ts
@@ -13,6 +13,7 @@ interface EChartsAxisTooltipParam {
   seriesName?: string
   value: unknown
   color: unknown
+  seriesIndex?: unknown
   dataIndex?: unknown
 }
 
@@ -40,6 +41,8 @@ export function createAxisTooltipFormatter(options: AxisTooltipOptions = {}) {
           seriesName: item.seriesName,
           value: typeof item.value === 'number' ? item.value : null,
           color: typeof item.color === 'string' ? item.color : undefined,
+          seriesIndex:
+            typeof item.seriesIndex === 'number' ? item.seriesIndex : undefined,
           dataIndex:
             typeof item.dataIndex === 'number' ? item.dataIndex : undefined,
         })),

--- a/packages/charts/src/internal/tooltip/tooltip-echarts.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-echarts.ts
@@ -21,8 +21,8 @@ interface EChartsTooltipPositionSize {
 
 /**
  * Engine tooltip `formatter` for an axis-trigger tooltip: one row per series
- * at the hovered category (design-notes/bar-chart.md, Behaviour — "tooltip
- * shows data for the selected bars").
+ * at the hovered category, per the design spec's "tooltip shows data for the
+ * selected bars" behaviour.
  */
 export function formatAxisTooltip(
   params: EChartsAxisTooltipParam | EChartsAxisTooltipParam[]

--- a/packages/charts/src/internal/tooltip/tooltip-echarts.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-echarts.ts
@@ -13,6 +13,7 @@ interface EChartsAxisTooltipParam {
   seriesName?: string
   value: unknown
   color: unknown
+  dataIndex?: unknown
 }
 
 interface EChartsTooltipPositionSize {
@@ -39,6 +40,8 @@ export function createAxisTooltipFormatter(options: AxisTooltipOptions = {}) {
           seriesName: item.seriesName,
           value: typeof item.value === 'number' ? item.value : null,
           color: typeof item.color === 'string' ? item.color : undefined,
+          dataIndex:
+            typeof item.dataIndex === 'number' ? item.dataIndex : undefined,
         })),
         options
       )

--- a/packages/charts/src/internal/tooltip/tooltip-echarts.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-echarts.ts
@@ -1,0 +1,61 @@
+import { buildAxisTooltipData } from './tooltip-model'
+import { getTooltipPosition } from './tooltip-position'
+import { renderChartTooltip } from './tooltip-render'
+
+/**
+ * The subset of the engine's `CallbackDataParams` this module reads. Typed
+ * locally because the engine doesn't re-export that type from `echarts/core`
+ * or `echarts/components`.
+ */
+interface EChartsAxisTooltipParam {
+  name?: string
+  seriesName?: string
+  value: unknown
+  color: unknown
+}
+
+interface EChartsTooltipPositionSize {
+  contentSize: [number, number]
+  viewSize: [number, number]
+}
+
+/**
+ * Engine tooltip `formatter` for an axis-trigger tooltip: one row per series
+ * at the hovered category (design-notes/bar-chart.md, Behaviour — "tooltip
+ * shows data for the selected bars").
+ */
+export function formatAxisTooltip(
+  params: EChartsAxisTooltipParam | EChartsAxisTooltipParam[]
+): string {
+  const items = Array.isArray(params) ? params : [params]
+
+  return renderChartTooltip(
+    buildAxisTooltipData(
+      items.map((item) => ({
+        name: item.name,
+        seriesName: item.seriesName,
+        value: typeof item.value === 'number' ? item.value : null,
+        color: typeof item.color === 'string' ? item.color : undefined,
+      }))
+    )
+  )
+}
+
+/**
+ * Engine tooltip `position` bound to a resolved pixel offset.
+ */
+export function createTooltipPositioner(offset: number) {
+  return (
+    point: [number, number],
+    _params: unknown,
+    _el: HTMLDivElement | null,
+    _rect: unknown,
+    size: EChartsTooltipPositionSize
+  ): [number, number] =>
+    getTooltipPosition({
+      point,
+      contentSize: size.contentSize,
+      viewSize: size.viewSize,
+      offset,
+    })
+}

--- a/packages/charts/src/internal/tooltip/tooltip-model.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-model.ts
@@ -47,13 +47,28 @@ export interface AxisTooltipItem {
   color?: string
 }
 
+export interface AxisTooltipOptions {
+  /**
+   * Lists the rows in reverse series order. Set it when the chart paints later
+   * series *before* earlier ones along the reader's axis, so that the rows,
+   * read top-down, name the segments in the order they appear.
+   * @default false
+   */
+  reverse?: boolean
+}
+
 /**
  * Compiles an axis-trigger tooltip's raw item list — one item per series at
  * the hovered category — into the row model. A series with no bar at this
  * category (`null` value) drops its row instead of showing an empty value.
+ *
+ * The engine always hands the items over in series order; only the caller
+ * knows how its own geometry maps that order onto the screen, so row order is
+ * its call to make via `reverse`.
  */
 export function buildAxisTooltipData(
-  items: AxisTooltipItem[]
+  items: AxisTooltipItem[],
+  options: AxisTooltipOptions = {}
 ): ChartTooltipData {
   const rows = items
     .filter(
@@ -66,5 +81,10 @@ export function buildAxisTooltipData(
       color: item.color,
     }))
 
+  // Safe to mutate: `map` above already returned a fresh array.
+  if (options.reverse) rows.reverse()
+
+  // Every item in an axis trigger carries the same category name, so the
+  // first one still titles the tooltip whichever way the rows run.
   return { title: items[0]?.name, rows }
 }

--- a/packages/charts/src/internal/tooltip/tooltip-model.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-model.ts
@@ -1,9 +1,9 @@
 /**
  * A row's trend indicator. Bar charts never produce one today (their data
  * model carries no deltas); the type exists now because the tooltip row
- * model (title / value / variation) is shared design, per
- * design-notes/tooltip.md — a future chart with period-over-period data
- * (e.g. LineChart) renders it through the same `renderChartTooltip`.
+ * model (title / value / variation) is shared design — a future chart with
+ * period-over-period data (e.g. LineChart) renders it through the same
+ * `renderChartTooltip`.
  */
 export interface ChartTooltipVariation {
   /**

--- a/packages/charts/src/internal/tooltip/tooltip-model.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-model.ts
@@ -1,0 +1,70 @@
+/**
+ * A row's trend indicator. Bar charts never produce one today (their data
+ * model carries no deltas); the type exists now because the tooltip row
+ * model (title / value / variation) is shared design, per
+ * design-notes/tooltip.md — a future chart with period-over-period data
+ * (e.g. LineChart) renders it through the same `renderChartTooltip`.
+ */
+export interface ChartTooltipVariation {
+  /**
+   * Formatted variation value, e.g. `'12.4%'`.
+   */
+  value: string
+  /**
+   * Arrow direction. `'flat'` renders no arrow.
+   */
+  direction: 'up' | 'down' | 'flat'
+  /**
+   * Semantic color of the value and arrow.
+   * @default 'neutral'
+   */
+  tone?: 'success' | 'critical' | 'neutral'
+}
+
+export interface ChartTooltipRow {
+  label: string
+  value: string
+  /**
+   * Series color swatch rendered as the row's left line.
+   */
+  color?: string
+  variation?: ChartTooltipVariation
+}
+
+export interface ChartTooltipData {
+  title?: string
+  rows: ChartTooltipRow[]
+}
+
+export interface AxisTooltipItem {
+  /**
+   * The hovered category's label, shared by every item in an axis-trigger
+   * tooltip.
+   */
+  name?: string
+  seriesName?: string
+  value: number | null | undefined
+  color?: string
+}
+
+/**
+ * Compiles an axis-trigger tooltip's raw item list — one item per series at
+ * the hovered category — into the row model. A series with no bar at this
+ * category (`null` value) drops its row instead of showing an empty value.
+ */
+export function buildAxisTooltipData(
+  items: AxisTooltipItem[]
+): ChartTooltipData {
+  const rows = items
+    .filter(
+      (item): item is AxisTooltipItem & { value: number } =>
+        typeof item.value === 'number'
+    )
+    .map((item) => ({
+      label: item.seriesName ?? '',
+      value: String(item.value),
+      color: item.color,
+    }))
+
+  return { title: items[0]?.name, rows }
+}

--- a/packages/charts/src/internal/tooltip/tooltip-model.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-model.ts
@@ -1,21 +1,26 @@
 /**
- * A row's trend indicator. Bar charts never produce one today (their data
- * model carries no deltas); the type exists now because the tooltip row
- * model (title / value / variation) is shared design — a future chart with
- * period-over-period data (e.g. LineChart) renders it through the same
- * `renderChartTooltip`.
+ * A row's change over the compared period, shown beside its value. Not a
+ * tooltip variant: there is one tooltip, and a row renders a delta only when
+ * its data carries one, so charts whose data model has no deltas — every bar
+ * chart today — simply omit it.
  */
-export interface ChartTooltipVariation {
+export interface ChartTooltipDelta {
   /**
-   * Formatted variation value, e.g. `'12.4%'`.
+   * The change, already formatted by the caller, who therefore picks the unit:
+   * `'12.4%'` for a ratio, `'2.3 pp'` for a move in percentage points. Being a
+   * string is also why `direction` can't be inferred — the sign is gone.
    */
   value: string
   /**
-   * Arrow direction. `'flat'` renders no arrow.
+   * Which way the value moved. Factual, and independent of `tone`; `'flat'`
+   * renders no arrow.
    */
   direction: 'up' | 'down' | 'flat'
   /**
-   * Semantic color of the value and arrow.
+   * Whether that movement reads as good, bad, or neither — semantic, and
+   * independent of `direction`, because a decrease is not inherently bad:
+   * falling mortality is `direction: 'down'` with `tone: 'success'`. Left
+   * alone, a delta stays uncolored rather than guessing from the sign.
    * @default 'neutral'
    */
   tone?: 'success' | 'critical' | 'neutral'
@@ -28,7 +33,7 @@ export interface ChartTooltipRow {
    * Series color swatch rendered as the row's left line.
    */
   color?: string
-  variation?: ChartTooltipVariation
+  delta?: ChartTooltipDelta
 }
 
 export interface ChartTooltipData {

--- a/packages/charts/src/internal/tooltip/tooltip-model.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-model.ts
@@ -50,6 +50,11 @@ export interface AxisTooltipItem {
   seriesName?: string
   value: number | null | undefined
   color?: string
+  /**
+   * Position of the hovered category, which together with the series name
+   * identifies the one data point a delta belongs to.
+   */
+  dataIndex?: number
 }
 
 export interface AxisTooltipOptions {
@@ -60,6 +65,17 @@ export interface AxisTooltipOptions {
    * @default false
    */
   reverse?: boolean
+  /**
+   * Resolves a row's delta from the series it names and the category it sits
+   * at, returning `undefined` where there is nothing to compare against. Left
+   * unset, no row shows a delta — the case for every chart whose data carries
+   * no comparison period.
+   * @default undefined
+   */
+  getDelta?: (
+    seriesName: string,
+    dataIndex: number
+  ) => ChartTooltipDelta | undefined
 }
 
 /**
@@ -69,25 +85,38 @@ export interface AxisTooltipOptions {
  *
  * The engine always hands the items over in series order; only the caller
  * knows how its own geometry maps that order onto the screen, so row order is
- * its call to make via `reverse`.
+ * its call to make via `reverse`. Deltas come from `getDelta` for the same
+ * reason: the row model knows which point a row describes, not what it should
+ * be compared against.
  */
 export function buildAxisTooltipData(
   items: AxisTooltipItem[],
   options: AxisTooltipOptions = {}
 ): ChartTooltipData {
+  const { reverse, getDelta } = options
+
   const rows = items
     .filter(
       (item): item is AxisTooltipItem & { value: number } =>
         typeof item.value === 'number'
     )
-    .map((item) => ({
-      label: item.seriesName ?? '',
-      value: String(item.value),
-      color: item.color,
-    }))
+    .map((item) => {
+      const label = item.seriesName ?? ''
+      const delta =
+        getDelta && item.dataIndex !== undefined
+          ? getDelta(label, item.dataIndex)
+          : undefined
+
+      return {
+        label,
+        value: String(item.value),
+        color: item.color,
+        ...(delta && { delta }),
+      }
+    })
 
   // Safe to mutate: `map` above already returned a fresh array.
-  if (options.reverse) rows.reverse()
+  if (reverse) rows.reverse()
 
   // Every item in an axis trigger carries the same category name, so the
   // first one still titles the tooltip whichever way the rows run.

--- a/packages/charts/src/internal/tooltip/tooltip-model.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-model.ts
@@ -1,8 +1,8 @@
 /**
  * A row's change over the compared period, shown beside its value. Not a
  * tooltip variant: there is one tooltip, and a row renders a delta only when
- * its data carries one, so charts whose data model has no deltas — every bar
- * chart today — simply omit it.
+ * its data supplies one — a bar chart whose series carry no `deltas` simply
+ * omits it.
  */
 export interface ChartTooltipDelta {
   /**
@@ -51,7 +51,14 @@ export interface AxisTooltipItem {
   value: number | null | undefined
   color?: string
   /**
-   * Position of the hovered category, which together with the series name
+   * Position of the series the item belongs to. Identity for delta lookup is
+   * positional rather than by name, because names are not required to be
+   * unique and two series sharing one would otherwise resolve to the same
+   * delta.
+   */
+  seriesIndex?: number
+  /**
+   * Position of the hovered category, which together with `seriesIndex`
    * identifies the one data point a delta belongs to.
    */
   dataIndex?: number
@@ -66,14 +73,14 @@ export interface AxisTooltipOptions {
    */
   reverse?: boolean
   /**
-   * Resolves a row's delta from the series it names and the category it sits
-   * at, returning `undefined` where there is nothing to compare against. Left
-   * unset, no row shows a delta — the case for every chart whose data carries
-   * no comparison period.
+   * Resolves a row's delta from the position of its series and of the category
+   * it sits at, returning `undefined` where there is nothing to compare
+   * against. Left unset, no row shows a delta — the case for every chart whose
+   * data carries no comparison period.
    * @default undefined
    */
   getDelta?: (
-    seriesName: string,
+    seriesIndex: number,
     dataIndex: number
   ) => ChartTooltipDelta | undefined
 }
@@ -101,14 +108,15 @@ export function buildAxisTooltipData(
         typeof item.value === 'number'
     )
     .map((item) => {
-      const label = item.seriesName ?? ''
       const delta =
-        getDelta && item.dataIndex !== undefined
-          ? getDelta(label, item.dataIndex)
+        getDelta &&
+        item.seriesIndex !== undefined &&
+        item.dataIndex !== undefined
+          ? getDelta(item.seriesIndex, item.dataIndex)
           : undefined
 
       return {
-        label,
+        label: item.seriesName ?? '',
         value: String(item.value),
         color: item.color,
         ...(delta && { delta }),

--- a/packages/charts/src/internal/tooltip/tooltip-position.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-position.ts
@@ -1,0 +1,36 @@
+export interface TooltipPositionInput {
+  /**
+   * Mouse/data point, relative to the chart's own bounds.
+   */
+  point: [number, number]
+  contentSize: [number, number]
+  viewSize: [number, number]
+  /**
+   * Gap between the hovered point and the tooltip.
+   */
+  offset: number
+}
+
+/**
+ * `offset` px to the left or right of the hovered point, flipping sides by
+ * which half of the chart it falls in, vertically centered on the point —
+ * design-notes/tooltip.md, Positioning. Clamped so the tooltip never renders
+ * outside the chart's own bounds.
+ */
+export function getTooltipPosition(
+  input: TooltipPositionInput
+): [number, number] {
+  const { point, contentSize, viewSize, offset } = input
+  const [pointX, pointY] = point
+  const [contentWidth, contentHeight] = contentSize
+  const [viewWidth, viewHeight] = viewSize
+
+  const onLeftHalf = pointX < viewWidth / 2
+  const rawX = onLeftHalf ? pointX + offset : pointX - contentWidth - offset
+  const x = Math.min(Math.max(rawX, 0), Math.max(viewWidth - contentWidth, 0))
+
+  const rawY = pointY - contentHeight / 2
+  const y = Math.min(Math.max(rawY, 0), Math.max(viewHeight - contentHeight, 0))
+
+  return [x, y]
+}

--- a/packages/charts/src/internal/tooltip/tooltip-position.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-position.ts
@@ -13,8 +13,8 @@ export interface TooltipPositionInput {
 
 /**
  * `offset` px to the left or right of the hovered point, flipping sides by
- * which half of the chart it falls in, vertically centered on the point —
- * design-notes/tooltip.md, Positioning. Clamped so the tooltip never renders
+ * which half of the chart it falls in, vertically centered on the point, per
+ * the design spec's positioning rule. Clamped so the tooltip never renders
  * outside the chart's own bounds.
  */
 export function getTooltipPosition(

--- a/packages/charts/src/internal/tooltip/tooltip-position.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-position.ts
@@ -4,6 +4,10 @@ export interface TooltipPositionInput {
    */
   point: [number, number]
   contentSize: [number, number]
+  /**
+   * Chart bounds. Only used to pick the side to flip to — the result is not
+   * confined to them.
+   */
   viewSize: [number, number]
   /**
    * Gap between the hovered point and the tooltip.
@@ -14,8 +18,14 @@ export interface TooltipPositionInput {
 /**
  * `offset` px to the left or right of the hovered point, flipping sides by
  * which half of the chart it falls in, vertically centered on the point, per
- * the design spec's positioning rule. Clamped so the tooltip never renders
- * outside the chart's own bounds.
+ * the design spec's positioning rule.
+ *
+ * Deliberately unclamped: the tooltip is allowed to overflow the chart's own
+ * bounds rather than being pushed back inside them. Clamping moved the tooltip
+ * off the hovered bar on small charts, which reads as pointing at the wrong
+ * category — worse than overlapping whatever sits next to the chart. The half
+ * flip already keeps it inside the chart in the common case, and `viewSize` is
+ * still what that flip is measured against.
  */
 export function getTooltipPosition(
   input: TooltipPositionInput
@@ -23,14 +33,11 @@ export function getTooltipPosition(
   const { point, contentSize, viewSize, offset } = input
   const [pointX, pointY] = point
   const [contentWidth, contentHeight] = contentSize
-  const [viewWidth, viewHeight] = viewSize
+  const [viewWidth] = viewSize
 
   const onLeftHalf = pointX < viewWidth / 2
-  const rawX = onLeftHalf ? pointX + offset : pointX - contentWidth - offset
-  const x = Math.min(Math.max(rawX, 0), Math.max(viewWidth - contentWidth, 0))
-
-  const rawY = pointY - contentHeight / 2
-  const y = Math.min(Math.max(rawY, 0), Math.max(viewHeight - contentHeight, 0))
+  const x = onLeftHalf ? pointX + offset : pointX - contentWidth - offset
+  const y = pointY - contentHeight / 2
 
   return [x, y]
 }

--- a/packages/charts/src/internal/tooltip/tooltip-render.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-render.ts
@@ -1,0 +1,55 @@
+import type {
+  ChartTooltipData,
+  ChartTooltipRow,
+  ChartTooltipVariation,
+} from './tooltip-model'
+
+// The Figma "ChartTooltip" variation arrow — a filled triangle rotated by
+// CSS for the 'down' direction (tooltip.md row model).
+const variationIconPath =
+  'M3.34935 0.470001C3.74102 -0.156668 4.65368 -0.156667 5.04535 0.470002L8.2411 5.58321C8.65738 6.24925 8.17854 7.1132 7.3931 7.1132H1.0016C0.216164 7.1132 -0.262679 6.24925 0.153601 5.58321L3.34935 0.470001Z'
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function renderVariation(variation: ChartTooltipVariation): string {
+  const tone = variation.tone ?? 'neutral'
+  const icon =
+    variation.direction === 'flat'
+      ? ''
+      : `<svg data-sl-chart-tooltip-row-variation-icon viewBox="0 0 8.3947 7.1132" aria-hidden="true"><path d="${variationIconPath}" fill="currentColor" /></svg>`
+
+  return `<span data-sl-chart-tooltip-row-variation data-direction="${variation.direction}" data-tone="${tone}"><span data-sl-chart-tooltip-row-variation-value>${escapeHtml(variation.value)}</span>${icon}</span>`
+}
+
+function renderRow(row: ChartTooltipRow): string {
+  const line = row.color
+    ? `<span data-sl-chart-tooltip-row-line style="background-color:${escapeHtml(row.color)}"></span>`
+    : ''
+
+  return `<div data-sl-chart-tooltip-row>${line}<div data-sl-chart-tooltip-row-content><span data-sl-chart-tooltip-row-label>${escapeHtml(row.label)}</span><span data-sl-chart-tooltip-row-value-group><span data-sl-chart-tooltip-row-value>${escapeHtml(row.value)}</span>${row.variation ? renderVariation(row.variation) : ''}</span></div></div>`
+}
+
+/**
+ * Renders the tooltip row model (design-notes/tooltip.md) to an HTML string
+ * for the engine's tooltip `formatter`. The engine mounts this markup in its
+ * own floating DOM node outside the React tree, so it is styled entirely
+ * through the `data-sl-chart-tooltip*` hooks in `tooltip.css` — the only way
+ * this DOM-rendered part reaches `--sl-*` tokens, per FR-007.
+ */
+export function renderChartTooltip(data: ChartTooltipData): string {
+  if (data.rows.length === 0) return ''
+
+  const title = data.title
+    ? `<div data-sl-chart-tooltip-title>${escapeHtml(data.title)}</div>`
+    : ''
+  const rows = data.rows.map(renderRow).join('')
+
+  return `<div data-sl-chart-tooltip>${title}<div data-sl-chart-tooltip-rows>${rows}</div></div>`
+}

--- a/packages/charts/src/internal/tooltip/tooltip-render.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-render.ts
@@ -37,8 +37,8 @@ function renderRow(row: ChartTooltipRow): string {
 }
 
 /**
- * Renders the tooltip row model (design-notes/tooltip.md) to an HTML string
- * for the engine's tooltip `formatter`. The engine mounts this markup in its
+ * Renders the tooltip row model to an HTML string for the engine's tooltip
+ * `formatter`. The engine mounts this markup in its
  * own floating DOM node outside the React tree, so it is styled entirely
  * through the `data-sl-chart-tooltip*` hooks in `tooltip.css` — the only way
  * this DOM-rendered part reaches `--sl-*` tokens, per FR-007.

--- a/packages/charts/src/internal/tooltip/tooltip-render.ts
+++ b/packages/charts/src/internal/tooltip/tooltip-render.ts
@@ -1,12 +1,12 @@
 import type {
   ChartTooltipData,
+  ChartTooltipDelta,
   ChartTooltipRow,
-  ChartTooltipVariation,
 } from './tooltip-model'
 
-// The Figma "ChartTooltip" variation arrow — a filled triangle rotated by
+// The Figma "ChartTooltip" delta arrow — a filled triangle rotated by
 // CSS for the 'down' direction (tooltip.md row model).
-const variationIconPath =
+const deltaIconPath =
   'M3.34935 0.470001C3.74102 -0.156668 4.65368 -0.156667 5.04535 0.470002L8.2411 5.58321C8.65738 6.24925 8.17854 7.1132 7.3931 7.1132H1.0016C0.216164 7.1132 -0.262679 6.24925 0.153601 5.58321L3.34935 0.470001Z'
 
 function escapeHtml(value: string): string {
@@ -18,14 +18,14 @@ function escapeHtml(value: string): string {
     .replace(/'/g, '&#39;')
 }
 
-function renderVariation(variation: ChartTooltipVariation): string {
-  const tone = variation.tone ?? 'neutral'
+function renderDelta(delta: ChartTooltipDelta): string {
+  const tone = delta.tone ?? 'neutral'
   const icon =
-    variation.direction === 'flat'
+    delta.direction === 'flat'
       ? ''
-      : `<svg data-sl-chart-tooltip-row-variation-icon viewBox="0 0 8.3947 7.1132" aria-hidden="true"><path d="${variationIconPath}" fill="currentColor" /></svg>`
+      : `<svg data-sl-chart-tooltip-row-delta-icon viewBox="0 0 8.3947 7.1132" aria-hidden="true"><path d="${deltaIconPath}" fill="currentColor" /></svg>`
 
-  return `<span data-sl-chart-tooltip-row-variation data-direction="${variation.direction}" data-tone="${tone}"><span data-sl-chart-tooltip-row-variation-value>${escapeHtml(variation.value)}</span>${icon}</span>`
+  return `<span data-sl-chart-tooltip-row-delta data-direction="${delta.direction}" data-tone="${tone}"><span data-sl-chart-tooltip-row-delta-value>${escapeHtml(delta.value)}</span>${icon}</span>`
 }
 
 function renderRow(row: ChartTooltipRow): string {
@@ -33,7 +33,7 @@ function renderRow(row: ChartTooltipRow): string {
     ? `<span data-sl-chart-tooltip-row-line style="background-color:${escapeHtml(row.color)}"></span>`
     : ''
 
-  return `<div data-sl-chart-tooltip-row>${line}<div data-sl-chart-tooltip-row-content><span data-sl-chart-tooltip-row-label>${escapeHtml(row.label)}</span><span data-sl-chart-tooltip-row-value-group><span data-sl-chart-tooltip-row-value>${escapeHtml(row.value)}</span>${row.variation ? renderVariation(row.variation) : ''}</span></div></div>`
+  return `<div data-sl-chart-tooltip-row>${line}<div data-sl-chart-tooltip-row-content><span data-sl-chart-tooltip-row-label>${escapeHtml(row.label)}</span><span data-sl-chart-tooltip-row-value-group><span data-sl-chart-tooltip-row-value>${escapeHtml(row.value)}</span>${row.delta ? renderDelta(row.delta) : ''}</span></div></div>`
 }
 
 /**

--- a/packages/charts/src/internal/tooltip/tooltip.css
+++ b/packages/charts/src/internal/tooltip/tooltip.css
@@ -64,7 +64,7 @@
   letter-spacing: var(--sl-text-display-3-letter-spacing);
 }
 
-[data-sl-chart-tooltip-row-variation] {
+[data-sl-chart-tooltip-row-delta] {
   display: flex;
   flex-shrink: 0;
   align-items: center;
@@ -74,24 +74,24 @@
   white-space: nowrap;
 }
 
-[data-sl-chart-tooltip-row-variation][data-tone="success"] {
+[data-sl-chart-tooltip-row-delta][data-tone="success"] {
   color: var(--sl-fg-success);
 }
 
-[data-sl-chart-tooltip-row-variation][data-tone="critical"] {
+[data-sl-chart-tooltip-row-delta][data-tone="critical"] {
   color: var(--sl-fg-critical);
 }
 
-[data-sl-chart-tooltip-row-variation][data-tone="neutral"] {
+[data-sl-chart-tooltip-row-delta][data-tone="neutral"] {
   color: var(--sl-fg-base-soft);
 }
 
-[data-sl-chart-tooltip-row-variation-icon] {
+[data-sl-chart-tooltip-row-delta-icon] {
   width: 0.625rem;
   height: 0.5rem;
 }
 
-[data-sl-chart-tooltip-row-variation][data-direction="down"]
-  [data-sl-chart-tooltip-row-variation-icon] {
+[data-sl-chart-tooltip-row-delta][data-direction="down"]
+  [data-sl-chart-tooltip-row-delta-icon] {
   transform: rotate(180deg);
 }

--- a/packages/charts/src/internal/tooltip/tooltip.css
+++ b/packages/charts/src/internal/tooltip/tooltip.css
@@ -1,0 +1,97 @@
+[data-sl-chart-tooltip] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sl-space-2);
+  /* design-notes/tooltip.md: small (128px, no deltas) / max (268px, with deltas) Figma frames */
+  min-width: 8rem;
+  max-width: 16.75rem;
+  padding: var(--sl-space-3) var(--sl-space-4);
+  background: var(--sl-bg-base);
+  border: var(--sl-border-base);
+  border-radius: var(--sl-radius-2);
+  box-shadow: var(--sl-shadow-1);
+}
+
+[data-sl-chart-tooltip-title] {
+  color: var(--sl-fg-base);
+  font: var(--sl-text-caption-1-font);
+  letter-spacing: var(--sl-text-caption-1-letter-spacing);
+}
+
+[data-sl-chart-tooltip-rows] {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sl-space-2);
+}
+
+[data-sl-chart-tooltip-row] {
+  display: flex;
+  align-items: stretch;
+  gap: var(--sl-space-2);
+}
+
+[data-sl-chart-tooltip-row-line] {
+  flex-shrink: 0;
+  width: 0.25rem;
+  margin-block: var(--sl-space-05);
+  border-radius: var(--sl-radius-1);
+}
+
+[data-sl-chart-tooltip-row-content] {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  min-width: 0;
+}
+
+[data-sl-chart-tooltip-row-label] {
+  color: var(--sl-fg-base-soft);
+  font: var(--sl-text-body-font);
+  letter-spacing: var(--sl-text-body-letter-spacing);
+}
+
+[data-sl-chart-tooltip-row-value-group] {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sl-space-4);
+}
+
+[data-sl-chart-tooltip-row-value] {
+  color: var(--sl-fg-base);
+  font: var(--sl-text-display-3-font);
+  letter-spacing: var(--sl-text-display-3-letter-spacing);
+}
+
+[data-sl-chart-tooltip-row-variation] {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--sl-space-05);
+  font: var(--sl-text-emphasis-font);
+  letter-spacing: var(--sl-text-emphasis-letter-spacing);
+  white-space: nowrap;
+}
+
+[data-sl-chart-tooltip-row-variation][data-tone="success"] {
+  color: var(--sl-fg-success);
+}
+
+[data-sl-chart-tooltip-row-variation][data-tone="critical"] {
+  color: var(--sl-fg-critical);
+}
+
+[data-sl-chart-tooltip-row-variation][data-tone="neutral"] {
+  color: var(--sl-fg-base-soft);
+}
+
+[data-sl-chart-tooltip-row-variation-icon] {
+  width: 0.625rem;
+  height: 0.5rem;
+}
+
+[data-sl-chart-tooltip-row-variation][data-direction="down"]
+  [data-sl-chart-tooltip-row-variation-icon] {
+  transform: rotate(180deg);
+}

--- a/packages/charts/src/internal/tooltip/tooltip.css
+++ b/packages/charts/src/internal/tooltip/tooltip.css
@@ -4,7 +4,7 @@
   gap: var(--sl-space-2);
   /* Figma frames: small (128px, no deltas) / max (268px, with deltas) */
   min-width: 8rem;
-  max-width: 16.75rem;
+  max-width: 17.05rem;
   padding: var(--sl-space-3) var(--sl-space-4);
   background: var(--sl-bg-base);
   border: var(--sl-border-base);

--- a/packages/charts/src/internal/tooltip/tooltip.css
+++ b/packages/charts/src/internal/tooltip/tooltip.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   gap: var(--sl-space-2);
-  /* design-notes/tooltip.md: small (128px, no deltas) / max (268px, with deltas) Figma frames */
+  /* Figma frames: small (128px, no deltas) / max (268px, with deltas) */
   min-width: 8rem;
   max-width: 16.75rem;
   padding: var(--sl-space-3) var(--sl-space-4);

--- a/packages/charts/src/styles.css
+++ b/packages/charts/src/styles.css
@@ -1,2 +1,3 @@
 @import "./internal/chart-container/chart-container.css";
+@import "./internal/tooltip/tooltip.css";
 @import "./components/bar-chart/bar-chart.css";


### PR DESCRIPTION
## Summary
Row-model tooltip rendered as Shoreline DOM, not the engine's default tooltip chrome:

- `internal/tooltip/`: title/value/variation row model, HTML-escaped render function, and the 8px offset + half-container flip position rule as pure, independently tested functions; a thin echarts adapter binds them to the engine's formatter/position callback shapes
- Variation row type modeled per the design spec but unused by `BarChart` today (its data has no deltas) — ready for a future chart type
- Wired into `bar-option.ts`: tooltip visuals come entirely from `data-sl-chart-tooltip*` CSS + `--sl-*` tokens; axis-pointer shadow themed with `--sl-bg-muted-plain-hover` per the design spec's hover behaviour
- Removes the now-superseded theme-level tooltip styling from `chart-theme.ts`, which the per-chart formatter always overrides
- `internal/tooltip/stories/tooltip.show.stories.tsx`: a Chromatic-enabled variant matrix (small/max Figma frames, variation directions and tones, edge cases) for design review of the row model in isolation, since it has no public component to host a story under

Stacked on #2144 (bar chart component) — diff here is tooltip-only.

## Review focus
Tooltip visual fidelity against the Figma tooltip frames; row-model API shape for future chart types (line/area will reuse variation rows)

## Test plan
- [x] `pnpm test:ci` passes for `packages/charts`
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] Chromatic review of `tooltip.show.stories.tsx` against Figma tooltip frames


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable chart tooltips with clearer titles, values, color indicators, and trend variations.
  * Bar charts now support per-category change indicators, including partial comparison data and custom trend tones.
  * Tooltips intelligently position beside hovered data points and adapt to stacked bar layouts.
  * Added support for long content and overflow beyond chart boundaries.
* **Bug Fixes**
  * Improved rendering by filtering invalid values and safely escaping displayed content.
* **Documentation**
  * Added interactive examples covering tooltip sizes, variations, missing content, and long labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->