### PR TITLE
fix: document body not reachable when drawer is open

### DIFF
--- a/packages/shoreline/src/components/drawer/drawer-provider.tsx
+++ b/packages/shoreline/src/components/drawer/drawer-provider.tsx
@@ -1,11 +1,14 @@
 import type { ReactNode } from 'react'
 import { Drawer as Vaul } from 'vaul'
+import { useNonModalDrawerUnlock } from './use-non-modal-drawer-unlock'
 
 /**
  * Drawer's state provider
  */
 export function DrawerProvider(props: DrawerProviderProps) {
   const { children, open, onClose, onOpenChange, dismissible } = props
+
+  useNonModalDrawerUnlock(open)
 
   return (
     <Vaul.Root

--- a/packages/shoreline/src/components/drawer/stories/tests/modal-inside-drawer.stories.tsx
+++ b/packages/shoreline/src/components/drawer/stories/tests/modal-inside-drawer.stories.tsx
@@ -5,6 +5,7 @@ import {
   getByText,
   getByTestId,
   expect,
+  waitFor,
 } from '@storybook/test'
 import { ConfirmationModal } from '../../../confirmation-modal'
 import { Button } from '../../../button'
@@ -18,30 +19,35 @@ import { DrawerContent } from '../../drawer-content'
 
 export default {
   title: 'components/drawer/tests',
-  play: async () => {
+  play: async ({ canvasElement }: { canvasElement: HTMLElement }) => {
+    const canvas = within(canvasElement)
     // DrawerPopover portals outside #storybook-root
     const body = within(document.body)
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Open drawer' }), {
+      delay: 200,
+    })
+
+    await waitFor(() =>
+      expect(document.body.style.pointerEvents).not.toBe('none')
+    )
 
     const openModalButton = body.getByRole('button', {
       name: 'Open confirmation',
     })
+    const modal = getByTestId(document.body, 'confirmation-modal')
 
     await userEvent.click(openModalButton, { delay: 200 })
-
-    const modal = getByTestId(document.body, 'confirmation-modal')
     await expect(modal).toBeVisible()
 
-    const confirmButton = getByText(modal as HTMLElement, 'Confirm')
+    const confirmButton = getByText(modal, 'Confirm')
     await userEvent.click(confirmButton, { delay: 200 })
-    await expect(modal).not.toBeVisible()
+    await waitFor(() => expect(modal).not.toBeVisible())
 
     await userEvent.click(openModalButton, { delay: 200 })
-    const openModal = getByTestId(document.body, 'confirmation-modal')
-    const cancelButton = getByText(openModal as HTMLElement, 'Cancel')
+    const cancelButton = getByText(modal, 'Cancel')
     await userEvent.click(cancelButton, { delay: 200 })
-    await expect(
-      getByTestId(document.body, 'confirmation-modal')
-    ).not.toBeVisible()
+    await waitFor(() => expect(modal).not.toBeVisible())
   },
   parameters: {
     chromatic: { disableSnapshot: true },
@@ -49,6 +55,7 @@ export default {
 }
 
 export function ModalInsideDrawer() {
+  const [drawerOpen, setDrawerOpen] = useState(false)
   const [modalOpen, setModalOpen] = useState(false)
 
   const handleClose = () => {
@@ -56,25 +63,30 @@ export function ModalInsideDrawer() {
   }
 
   return (
-    <DrawerProvider open>
-      <DrawerPopover size="small">
-        <DrawerHeader>
-          <DrawerHeading>Drawer Heading</DrawerHeading>
-          <DrawerDismiss />
-        </DrawerHeader>
-        <DrawerContent>
-          <Button onClick={() => setModalOpen(true)}>Open confirmation</Button>
-          <ConfirmationModal
-            data-testid="confirmation-modal"
-            open={modalOpen}
-            onClose={handleClose}
-            onConfirm={handleClose}
-            onCancel={handleClose}
-          >
-            <Text variant="body">This is a confirmation modal</Text>
-          </ConfirmationModal>
-        </DrawerContent>
-      </DrawerPopover>
-    </DrawerProvider>
+    <>
+      <Button onClick={() => setDrawerOpen(true)}>Open drawer</Button>
+      <DrawerProvider open={drawerOpen} onOpenChange={setDrawerOpen}>
+        <DrawerPopover size="small">
+          <DrawerHeader>
+            <DrawerHeading>Drawer Heading</DrawerHeading>
+            <DrawerDismiss />
+          </DrawerHeader>
+          <DrawerContent>
+            <Button onClick={() => setModalOpen(true)}>
+              Open confirmation
+            </Button>
+            <ConfirmationModal
+              data-testid="confirmation-modal"
+              open={modalOpen}
+              onClose={handleClose}
+              onConfirm={handleClose}
+              onCancel={handleClose}
+            >
+              <Text variant="body">This is a confirmation modal</Text>
+            </ConfirmationModal>
+          </DrawerContent>
+        </DrawerPopover>
+      </DrawerProvider>
+    </>
   )
 }

--- a/packages/shoreline/src/components/drawer/stories/tests/modal-inside-drawer.stories.tsx
+++ b/packages/shoreline/src/components/drawer/stories/tests/modal-inside-drawer.stories.tsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+import {
+  userEvent,
+  within,
+  getByText,
+  getByTestId,
+  expect,
+} from '@storybook/test'
+import { ConfirmationModal } from '../../../confirmation-modal'
+import { Button } from '../../../button'
+import { Text } from '../../../text'
+import { DrawerProvider } from '../../drawer-provider'
+import { DrawerPopover } from '../../drawer-popover'
+import { DrawerHeader } from '../../drawer-header'
+import { DrawerHeading } from '../../drawer-heading'
+import { DrawerDismiss } from '../../drawer-dismiss'
+import { DrawerContent } from '../../drawer-content'
+
+export default {
+  title: 'components/drawer/tests',
+  play: async () => {
+    // DrawerPopover portals outside #storybook-root
+    const body = within(document.body)
+
+    const openModalButton = body.getByRole('button', {
+      name: 'Open confirmation',
+    })
+
+    await userEvent.click(openModalButton, { delay: 200 })
+
+    const modal = getByTestId(document.body, 'confirmation-modal')
+    await expect(modal).toBeVisible()
+
+    const confirmButton = getByText(modal as HTMLElement, 'Confirm')
+    await userEvent.click(confirmButton, { delay: 200 })
+    await expect(modal).not.toBeVisible()
+
+    await userEvent.click(openModalButton, { delay: 200 })
+    const openModal = getByTestId(document.body, 'confirmation-modal')
+    const cancelButton = getByText(openModal as HTMLElement, 'Cancel')
+    await userEvent.click(cancelButton, { delay: 200 })
+    await expect(
+      getByTestId(document.body, 'confirmation-modal')
+    ).not.toBeVisible()
+  },
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
+}
+
+export function ModalInsideDrawer() {
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const handleClose = () => {
+    setModalOpen(false)
+  }
+
+  return (
+    <DrawerProvider open>
+      <DrawerPopover size="small">
+        <DrawerHeader>
+          <DrawerHeading>Drawer Heading</DrawerHeading>
+          <DrawerDismiss />
+        </DrawerHeader>
+        <DrawerContent>
+          <Button onClick={() => setModalOpen(true)}>Open confirmation</Button>
+          <ConfirmationModal
+            data-testid="confirmation-modal"
+            open={modalOpen}
+            onClose={handleClose}
+            onConfirm={handleClose}
+            onCancel={handleClose}
+          >
+            <Text variant="body">This is a confirmation modal</Text>
+          </ConfirmationModal>
+        </DrawerContent>
+      </DrawerPopover>
+    </DrawerProvider>
+  )
+}

--- a/packages/shoreline/src/components/drawer/tests/use-non-modal-drawer-unlock.test.tsx
+++ b/packages/shoreline/src/components/drawer/tests/use-non-modal-drawer-unlock.test.tsx
@@ -57,7 +57,7 @@ describe('useNonModalDrawerUnlock', () => {
     fireEvent.click(getByRole('button', { name: 'Open drawer' }))
 
     await waitFor(() => {
-      expect(document.body.style.pointerEvents).not.toBe('none')
+      expect(document.body.style.pointerEvents).toBe('auto')
     })
   })
 
@@ -66,12 +66,12 @@ describe('useNonModalDrawerUnlock', () => {
 
     rerender(<DrawerShell open />)
     await waitFor(() => {
-      expect(document.body.style.pointerEvents).not.toBe('none')
+      expect(document.body.style.pointerEvents).toBe('auto')
     })
 
     rerender(<DrawerShell open={false} />)
     await waitFor(() => {
-      expect(document.body.style.pointerEvents).not.toBe('auto')
+      expect(document.body.style.pointerEvents).toBe('')
     })
   })
 })

--- a/packages/shoreline/src/components/drawer/tests/use-non-modal-drawer-unlock.test.tsx
+++ b/packages/shoreline/src/components/drawer/tests/use-non-modal-drawer-unlock.test.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react'
+import {
+  afterEach,
+  describe,
+  expect,
+  it,
+  render,
+  fireEvent,
+  waitFor,
+} from '@vtex/shoreline-test-utils'
+import { DrawerProvider } from '../drawer-provider'
+import { DrawerPopover } from '../drawer-popover'
+import { DrawerContent } from '../drawer-content'
+import { DrawerHeader } from '../drawer-header'
+import { DrawerHeading } from '../drawer-heading'
+
+function DrawerShell({
+  open,
+  onOpenChange,
+}: {
+  open: boolean
+  onOpenChange?: (open: boolean) => void
+}) {
+  return (
+    <DrawerProvider open={open} onOpenChange={onOpenChange}>
+      <DrawerPopover size="small">
+        <DrawerHeader>
+          <DrawerHeading>Drawer Heading</DrawerHeading>
+        </DrawerHeader>
+        <DrawerContent>Drawer content</DrawerContent>
+      </DrawerPopover>
+    </DrawerProvider>
+  )
+}
+
+function ControlledDrawer() {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)}>
+        Open drawer
+      </button>
+      <DrawerShell open={open} onOpenChange={setOpen} />
+    </>
+  )
+}
+
+describe('useNonModalDrawerUnlock', () => {
+  afterEach(() => {
+    document.body.style.pointerEvents = ''
+  })
+
+  it('unlocks body pointer-events after a controlled open flip', async () => {
+    const { getByRole } = render(<ControlledDrawer />)
+
+    fireEvent.click(getByRole('button', { name: 'Open drawer' }))
+
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none')
+    })
+  })
+
+  it('clears body pointer-events written by the unlock on close', async () => {
+    const { rerender } = render(<DrawerShell open={false} />)
+
+    rerender(<DrawerShell open />)
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('none')
+    })
+
+    rerender(<DrawerShell open={false} />)
+    await waitFor(() => {
+      expect(document.body.style.pointerEvents).not.toBe('auto')
+    })
+  })
+})

--- a/packages/shoreline/src/components/drawer/use-non-modal-drawer-unlock.ts
+++ b/packages/shoreline/src/components/drawer/use-non-modal-drawer-unlock.ts
@@ -1,0 +1,37 @@
+import { useEffect } from 'react'
+
+/**
+ * TODO: remove when Vaul Drawer.Root forwards `modal`
+ * https://github.com/emilkowalski/vaul/pull/580
+ * https://github.com/radix-ui/primitives/issues/3141
+ */
+export function useNonModalDrawerUnlock(open: boolean | undefined) {
+  useEffect(() => {
+    if (!open) return
+
+    const body = document.body
+
+    const unlock = () => {
+      if (body.style.pointerEvents === 'none') {
+        body.style.pointerEvents = 'auto'
+      }
+    }
+
+    unlock()
+    const raf = requestAnimationFrame(unlock)
+
+    const observer = new MutationObserver(unlock)
+    observer.observe(body, {
+      attributes: true,
+      attributeFilter: ['style'],
+    })
+
+    return () => {
+      cancelAnimationFrame(raf)
+      observer.disconnect()
+      if (body.style.pointerEvents === 'auto') {
+        body.style.pointerEvents = ''
+      }
+    }
+  }, [open])
+}

--- a/packages/shoreline/src/components/drawer/use-non-modal-drawer-unlock.ts
+++ b/packages/shoreline/src/components/drawer/use-non-modal-drawer-unlock.ts
@@ -4,17 +4,22 @@ import { useEffect } from 'react'
  * TODO: remove when Vaul Drawer.Root forwards `modal`
  * https://github.com/emilkowalski/vaul/pull/580
  * https://github.com/radix-ui/primitives/issues/3141
+ *
+ * While the drawer is open, this observer reverts any `body { pointer-events: none }`
+ * within a microtask — including one set by a nested Radix overlay. Shoreline's own
+ * Modal/ConfirmationModal use Ariakit and do not write body pointer-events.
  */
 export function useNonModalDrawerUnlock(open: boolean | undefined) {
   useEffect(() => {
     if (!open) return
 
     const body = document.body
+    let didUnlock = false
 
     const unlock = () => {
-      if (body.style.pointerEvents === 'none') {
-        body.style.pointerEvents = 'auto'
-      }
+      if (body.style.pointerEvents !== 'none') return
+      body.style.pointerEvents = 'auto'
+      didUnlock = true
     }
 
     unlock()
@@ -29,7 +34,7 @@ export function useNonModalDrawerUnlock(open: boolean | undefined) {
     return () => {
       cancelAnimationFrame(raf)
       observer.disconnect()
-      if (body.style.pointerEvents === 'auto') {
+      if (didUnlock && body.style.pointerEvents === 'auto') {
         body.style.pointerEvents = ''
       }
     }


### PR DESCRIPTION

<!-- Explain the change motivation -->
## Summary

- Unlocks `document.body` `pointer-events` while a controlled `DrawerProvider` is open, so portaled overlays (e.g. `ConfirmationModal`) remain clickable.
- Works around Vaul `1.1.2` not forwarding `modal={false}` from `Drawer.Root` ([vaul#580](https://github.com/emilkowalski/vaul/pull/580); [radix#3141](https://github.com/radix-ui/primitives/issues/3141)).
- Adds a Storybook play test for opening/confirming/canceling a confirmation modal from inside the drawer.

## Examples

Do not change the component API.
<!-- Some code examples -->

https://github.com/user-attachments/assets/7b1fc441-42da-423a-b304-8ed74e9550bc



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interaction with non-modal drawers so the page remains responsive while a drawer is open.
  - Fixed pointer interaction issues when displaying confirmation modals inside drawers.
  - Ensured page interaction is restored reliably when drawers close.

- **Tests**
  - Added coverage for opening, confirming, and canceling modals displayed within drawers.
  - Added verification that pointer interactions are restored when drawers open and close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->