### PR TITLE
docs(charts): mark BarChart as experimental in the guide

### DIFF
--- a/packages/docs/pages/components/bar-chart.mdx
+++ b/packages/docs/pages/components/bar-chart.mdx
@@ -2,6 +2,12 @@
 
 <ComponentDescription name="bar-chart" />
 
+import { Callout } from 'nextra/components'
+
+<Callout type="warning" emoji="🧪">
+  **Experimental.** `BarChart` is not stable yet: it ships in `@vtex/shoreline-charts` at `0.x`, so its API and visuals may change between minor versions. Use it with that in mind.
+</Callout>
+
 <Preview name="bar-chart" />
 
 `BarChart` lives in the separate `@vtex/shoreline-charts` package. Install it and import its stylesheet once in your app:

--- a/packages/docs/pages/components/bar-chart.mdx
+++ b/packages/docs/pages/components/bar-chart.mdx
@@ -5,7 +5,7 @@
 import { Callout } from 'nextra/components'
 
 <Callout type="warning" emoji="🧪">
-  **Experimental.** `BarChart` is not stable yet: it ships in `@vtex/shoreline-charts` at `0.x`, so its API and visuals may change between minor versions. Use it with that in mind.
+  **Experimental.**  BarChart is not stable yet: it ships in `@vtex/shoreline-charts` at 0.x, so its API and visuals may change between minor versions.
 </Callout>
 
 <Preview name="bar-chart" />


### PR DESCRIPTION
## Summary

Follow-up to #2147 addressing the post-merge feedback on the BarChart docs. Three points were raised:

1. **No beta/rc npm dist-tag needed** — the package is at `0.x`, which already signals instability.
2. **Mark it experimental in the docs** so consumers know.
3. **Indicate it in the JSDoc** if possible.

## What changed

### 1. Beta/rc tag — no change needed
`@vtex/shoreline-charts` publishes with only a `latest` dist-tag (currently `0.2.1`) and the release workflow (`lerna publish` with no `--tag`) introduces no `beta`/`rc` tag. The `0.x` version already conveys instability, so nothing to add or remove.

### 2. Experimental notice in the docs — added
Added a Nextra `<Callout>` right under the component description on `bar-chart.mdx`, the page consumers land on to install and use the component:

```mdx
<Callout type="warning" emoji="🧪">
  **Experimental.** `BarChart` is not stable yet: it ships in `@vtex/shoreline-charts` at `0.x`, so its API and visuals may change between minor versions. Use it with that in mind.
</Callout>
```

This mirrors the existing `Callout` pattern used in `table/figma-usage.mdx`.

### 3. JSDoc — already present
`BarChart` already carries `@status experimental` in its JSDoc (`packages/charts/src/components/bar-chart/bar-chart.tsx`), matching the `@status` convention from the documentation guideline. The props build picks it up — `__props__/index.ts` has `status: 'experimental'` for `bar-chart` — so the experimental status is captured in the generated docs data. No change needed.

## Test plan
- [x] `pnpm --filter @shoreline/docs gen:props` succeeds — `bar-chart` still resolves with `status: 'experimental'`
- [x] `pnpm --filter @shoreline/docs gen:examples` succeeds
- [x] `next build` in `packages/docs` succeeds (full site)
- [x] The Callout renders in the built `/components/bar-chart` HTML (`Experimental.` / `not stable yet: it ships in`)

## Related
- #2147 — `docs(charts): add bar chart guide and best practices` (the merged PR this follows up on)

## Session cost
- Total cost: $0.00 (measured from the pi session log)
- Agent pi 0.84.1, model huawei/glm-5.2-vision (reasoning: off), 43 assistant turns
- Token breakdown: 85K input · 15K output · 9.8K reasoning · 1.1M cache-read (~1.2M total)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an experimental warning to the `BarChart` documentation.
  * Clarified that the component is unstable and may change between minor versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->