### PR TITLE
chore(charts): upgrade echarts from 5.6 to 6.1

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -53,6 +53,6 @@
   },
   "dependencies": {
     "@vtex/shoreline-utils": "workspace:*",
-    "echarts": "5.6.0"
+    "echarts": "6.1.0"
   }
 }

--- a/packages/charts/src/components/bar-chart/bar-option.ts
+++ b/packages/charts/src/components/bar-chart/bar-option.ts
@@ -242,7 +242,8 @@ export function buildBarOption(args: BuildBarOptionArgs): EChartsCoreOption {
       ),
     },
     grid: {
-      containLabel: true,
+      outerBoundsMode: 'same',
+      outerBoundsContain: 'axisLabel',
       left: tokens.px(spaceSmall),
       right: tokens.px(spaceSmall),
       top: tokens.px(spaceSmall),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ importers:
     dependencies:
       '@storybook/test':
         specifier: ^8.6.15
-        version: 8.6.15(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(storybook@8.6.15(prettier@3.9.6))
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -38,37 +38,37 @@ importers:
         version: 1.44.1
       '@storybook/addon-a11y':
         specifier: ^8.6.15
-        version: 8.6.15(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@storybook/addon-actions':
         specifier: ^8.6.15
-        version: 8.6.15(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@storybook/addon-essentials':
         specifier: ^8.6.15
-        version: 8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.9.6))
       '@storybook/addon-interactions':
         specifier: ^8.6.15
-        version: 8.6.15(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@storybook/addon-links':
         specifier: ^8.6.15
-        version: 8.6.15(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))
       '@storybook/addon-storysource':
         specifier: ^8.6.15
-        version: 8.6.15(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@storybook/react':
         specifier: ^8.6.15
-        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)
+        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)
       '@storybook/react-vite':
         specifier: ^8.6.15
-        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.0)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))
+        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.0)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))
       '@storybook/react-webpack5':
         specifier: ^8.6.15
-        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)
+        version: 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)
       '@storybook/test-runner':
         specifier: ^0.17.0
-        version: 0.17.0(@swc/helpers@0.5.13)(@types/node@20.14.9)(encoding@0.1.13)(prettier@3.3.3)
+        version: 0.17.0(@swc/helpers@0.5.13)(@types/node@20.14.9)(encoding@0.1.13)(prettier@3.9.6)
       '@storybook/theming':
         specifier: ^8.6.15
-        version: 8.6.15(storybook@8.6.15(prettier@3.3.3))
+        version: 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@types/node':
         specifier: 20.14.9
         version: 20.14.9
@@ -128,7 +128,7 @@ importers:
         version: 18.3.1(react@18.3.1)
       storybook:
         specifier: ^8.6.15
-        version: 8.6.15(prettier@3.3.3)
+        version: 8.6.15(prettier@3.9.6)
       tslib:
         specifier: 2.6.3
         version: 2.6.3
@@ -157,8 +157,8 @@ importers:
         specifier: workspace:*
         version: link:../utils
       echarts:
-        specifier: 5.6.0
-        version: 5.6.0
+        specifier: 6.1.0
+        version: 6.1.0
       react:
         specifier: '>=18.3'
         version: 18.3.1
@@ -5044,8 +5044,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  echarts@5.6.0:
-    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+  echarts@6.1.0:
+    resolution: {integrity: sha512-q0yaFPggC9FUdsWH4blavRWFmxdrIodbkoKNAjJudAI6CA9gNPxHtV2RcZNEepZVlk4yvBYkOkbk6HIVpIyHZA==}
 
   ejs@3.1.10:
     resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
@@ -8146,6 +8146,11 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  prettier@3.9.6:
+    resolution: {integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==}
+    engines: {node: '>=14'}
+    hasBin: true
+
   pretty-error@4.0.0:
     resolution: {integrity: sha512-AoJ5YMAcXKYxKhuJGdcvse+Voc6v1RgnsR3nWcYU7q4t6z0Q6T86sv5Zq8VIRbOWWFpvdGE83LtdSMNd+6Y0xw==}
 
@@ -9322,6 +9327,9 @@ packages:
   tslib@2.6.3:
     resolution: {integrity: sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsup@8.1.0:
     resolution: {integrity: sha512-UFdfCAXukax+U6KzeTNO2kAARHcWxmKsnvSPXUcfA1D+kU05XDccCrkffCQpFaWDsZfV0jMyTsxU39VfCp6EOg==}
     engines: {node: '>=18'}
@@ -10118,8 +10126,8 @@ packages:
   zod@3.25.58:
     resolution: {integrity: sha512-DVLmMQzSZwNYzQoMaM3MQWnxr2eq+AtM9Hx3w1/Yl0pH8sLTSjN4jGP7w6f7uand6Hw44tsnSu1hz1AOA6qI2Q==}
 
-  zrender@5.6.1:
-    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
+  zrender@6.1.0:
+    resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -10602,7 +10610,7 @@ snapshots:
 
   '@emnapi/runtime@1.3.1':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
     optional: true
 
   '@esbuild/aix-ppc64@0.19.12':
@@ -10872,26 +10880,26 @@ snapshots:
   '@formatjs/ecma402-abstract@2.0.0':
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@formatjs/fast-memoize@2.2.0':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@formatjs/icu-messageformat-parser@2.7.8':
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/icu-skeleton-parser': 1.8.2
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@formatjs/icu-skeleton-parser@1.8.2':
     dependencies:
       '@formatjs/ecma402-abstract': 2.0.0
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@formatjs/intl-localematcher@0.5.4':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@hapi/hoek@9.3.0': {}
 
@@ -12804,136 +12812,136 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storybook/addon-a11y@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-a11y@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      '@storybook/addon-highlight': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/addon-highlight': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@storybook/global': 5.0.0
-      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       axe-core: 4.9.1
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/addon-actions@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-actions@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-backgrounds@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-controls@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-docs@8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-docs@8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@mdx-js/react': 3.0.1(@types/react@18.3.11)(react@18.3.1)
-      '@storybook/blocks': 8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/csf-plugin': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/react-dom-shim': 8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/blocks': 8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/csf-plugin': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/react-dom-shim': 8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-essentials@8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      '@storybook/addon-actions': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-backgrounds': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-controls': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-docs': 8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-highlight': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-measure': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-outline': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-toolbars': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/addon-viewport': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      storybook: 8.6.15(prettier@3.3.3)
+      '@storybook/addon-actions': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-backgrounds': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-controls': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-docs': 8.6.15(@types/react@18.3.11)(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-highlight': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-measure': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-outline': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-toolbars': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/addon-viewport': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-highlight@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/addon-interactions@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-interactions@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/instrumenter': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       polished: 4.3.1
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@8.6.15(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-links@8.6.15(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 18.3.1
 
-  '@storybook/addon-measure@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-measure@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-outline@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-outline@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-storysource@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-storysource@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      '@storybook/source-loader': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/source-loader': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       estraverse: 5.3.0
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-toolbars@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-toolbars@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/addon-viewport@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/addon-viewport@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/blocks@8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/blocks@8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/icons': 1.2.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.6.15(storybook@8.6.15(prettier@3.3.3))(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))':
+  '@storybook/builder-vite@8.6.15(storybook@8.6.15(prettier@3.9.6))(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))':
     dependencies:
-      '@storybook/csf-plugin': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/csf-plugin': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       browser-assert: 1.2.1
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
       vite: 5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0)
 
-  '@storybook/builder-webpack5@8.6.15(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)':
+  '@storybook/builder-webpack5@8.6.15(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)':
     dependencies:
-      '@storybook/core-webpack': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/core-webpack': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@types/semver': 7.5.8
       browser-assert: 1.2.1
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -12947,7 +12955,7 @@ snapshots:
       path-browserify: 1.0.1
       process: 0.11.10
       semver: 7.6.3
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       style-loader: 3.3.4(webpack@5.91.0(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5))
       terser-webpack-plugin: 5.3.10(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(webpack@5.91.0(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5))
       ts-dedent: 2.2.0
@@ -12979,11 +12987,11 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/components@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/components@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/core-common@8.1.5(encoding@0.1.13)(prettier@3.3.3)':
+  '@storybook/core-common@8.1.5(encoding@0.1.13)(prettier@3.9.6)':
     dependencies:
       '@storybook/core-events': 8.1.5
       '@storybook/csf-tools': 8.1.5
@@ -13006,7 +13014,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       picomatch: 2.3.1
       pkg-dir: 5.0.0
-      prettier-fallback: prettier@3.3.3
+      prettier-fallback: prettier@3.9.6
       pretty-hrtime: 1.0.3
       resolve-from: 5.0.0
       semver: 7.6.3
@@ -13015,7 +13023,7 @@ snapshots:
       ts-dedent: 2.2.0
       util: 0.12.5
     optionalDependencies:
-      prettier: 3.3.3
+      prettier: 3.9.6
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13025,14 +13033,14 @@ snapshots:
       '@storybook/csf': 0.1.8
       ts-dedent: 2.2.0
 
-  '@storybook/core-webpack@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/core-webpack@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       ts-dedent: 2.2.0
 
-  '@storybook/core@8.6.15(prettier@3.3.3)(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/core@8.6.15(prettier@3.9.6)(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      '@storybook/theming': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/theming': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       better-opn: 3.0.2
       browser-assert: 1.2.1
       esbuild: 0.21.5
@@ -13044,16 +13052,16 @@ snapshots:
       util: 0.12.5
       ws: 8.17.0
     optionalDependencies:
-      prettier: 3.3.3
+      prettier: 3.9.6
     transitivePeerDependencies:
       - bufferutil
       - storybook
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/csf-plugin@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       unplugin: 1.10.1
 
   '@storybook/csf-tools@8.1.5':
@@ -13081,22 +13089,22 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/instrumenter@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/instrumenter@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.3
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/manager-api@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/manager-api@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
   '@storybook/node-logger@8.1.5': {}
 
-  '@storybook/preset-react-webpack@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)':
+  '@storybook/preset-react-webpack@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)':
     dependencies:
-      '@storybook/core-webpack': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/react': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)
+      '@storybook/core-webpack': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/react': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.5.2)(webpack@5.91.0(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5))
       '@types/semver': 7.5.8
       find-up: 5.0.0
@@ -13106,7 +13114,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
       semver: 7.6.3
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       tsconfig-paths: 4.2.0
       webpack: 5.91.0(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)
     optionalDependencies:
@@ -13136,9 +13144,9 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/preview-api@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/preview-api@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
   '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.5.2)(webpack@5.91.0(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5))':
     dependencies:
@@ -13154,42 +13162,42 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/react-dom-shim@8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/react-dom-shim@8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/react-vite@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.0)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))':
+  '@storybook/react-vite@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.24.0)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.5.0(typescript@5.5.2)(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))
       '@rollup/pluginutils': 5.1.0(rollup@4.24.0)
-      '@storybook/builder-vite': 8.6.15(storybook@8.6.15(prettier@3.3.3))(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))
-      '@storybook/react': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)
+      '@storybook/builder-vite': 8.6.15(storybook@8.6.15(prettier@3.9.6))(vite@5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0))
+      '@storybook/react': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)
       find-up: 5.0.0
       magic-string: 0.30.10
       react: 18.3.1
       react-docgen: 7.0.3
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.8
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
       tsconfig-paths: 4.2.0
       vite: 5.4.9(@types/node@20.14.9)(lightningcss@1.27.0)(terser@5.31.0)
     optionalDependencies:
-      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.9.6))
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react-webpack5@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)':
+  '@storybook/react-webpack5@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.15(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)
-      '@storybook/preset-react-webpack': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)
-      '@storybook/react': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)
+      '@storybook/builder-webpack5': 8.6.15(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)
+      '@storybook/preset-react-webpack': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(@swc/core@1.5.24(@swc/helpers@0.5.13))(esbuild@0.21.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)
+      '@storybook/react': 8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
     optionalDependencies:
       typescript: 5.5.2
     transitivePeerDependencies:
@@ -13201,36 +13209,36 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))(typescript@5.5.2)':
+  '@storybook/react@8.6.15(@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))(typescript@5.5.2)':
     dependencies:
-      '@storybook/components': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/components': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/preview-api': 8.6.15(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/react-dom-shim': 8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.3.3))
-      '@storybook/theming': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/manager-api': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/preview-api': 8.6.15(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/react-dom-shim': 8.6.15(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.15(prettier@3.9.6))
+      '@storybook/theming': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
     optionalDependencies:
-      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/test': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       typescript: 5.5.2
 
-  '@storybook/source-loader@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/source-loader@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       es-toolkit: 1.43.0
       estraverse: 5.3.0
       prettier: 3.3.3
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/test-runner@0.17.0(@swc/helpers@0.5.13)(@types/node@20.14.9)(encoding@0.1.13)(prettier@3.3.3)':
+  '@storybook/test-runner@0.17.0(@swc/helpers@0.5.13)(@types/node@20.14.9)(encoding@0.1.13)(prettier@3.9.6)':
     dependencies:
       '@babel/core': 7.24.6
       '@babel/generator': 7.24.6
       '@babel/template': 7.24.6
       '@babel/types': 7.24.6
       '@jest/types': 29.6.3
-      '@storybook/core-common': 8.1.5(encoding@0.1.13)(prettier@3.3.3)
+      '@storybook/core-common': 8.1.5(encoding@0.1.13)(prettier@3.9.6)
       '@storybook/csf': 0.1.8
       '@storybook/csf-tools': 8.1.5
       '@storybook/preview-api': 8.1.5
@@ -13257,20 +13265,20 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/test@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/test@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.6.15(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/instrumenter': 8.6.15(storybook@8.6.15(prettier@3.9.6))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
-  '@storybook/theming@8.6.15(storybook@8.6.15(prettier@3.3.3))':
+  '@storybook/theming@8.6.15(storybook@8.6.15(prettier@3.9.6))':
     dependencies:
-      storybook: 8.6.15(prettier@3.3.3)
+      storybook: 8.6.15(prettier@3.9.6)
 
   '@storybook/types@8.1.5':
     dependencies:
@@ -13329,11 +13337,11 @@ snapshots:
 
   '@swc/helpers@0.5.11':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@swc/helpers@0.5.13':
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   '@swc/jest@0.2.36(@swc/core@1.5.24(@swc/helpers@0.5.13))':
     dependencies:
@@ -14070,7 +14078,7 @@ snapshots:
 
   aria-hidden@1.2.4:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   aria-query@5.1.3:
     dependencies:
@@ -15366,10 +15374,10 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  echarts@5.6.0:
+  echarts@6.1.0:
     dependencies:
       tslib: 2.3.0
-      zrender: 5.6.1
+      zrender: 6.1.0
 
   ejs@3.1.10:
     dependencies:
@@ -16693,7 +16701,7 @@ snapshots:
       '@formatjs/ecma402-abstract': 2.0.0
       '@formatjs/fast-memoize': 2.2.0
       '@formatjs/icu-messageformat-parser': 2.7.8
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   invariant@2.2.4:
     dependencies:
@@ -19553,6 +19561,8 @@ snapshots:
 
   prettier@3.3.3: {}
 
+  prettier@3.9.6: {}
+
   pretty-error@4.0.0:
     dependencies:
       lodash: 4.18.1
@@ -19712,7 +19722,7 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-style-singleton: 2.2.1(@types/react@18.3.11)(react@18.3.1)
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -19721,7 +19731,7 @@ snapshots:
       react: 18.3.1
       react-remove-scroll-bar: 2.3.6(@types/react@18.3.11)(react@18.3.1)
       react-style-singleton: 2.2.1(@types/react@18.3.11)(react@18.3.1)
-      tslib: 2.6.3
+      tslib: 2.8.1
       use-callback-ref: 1.3.2(@types/react@18.3.11)(react@18.3.1)
       use-sidecar: 1.1.2(@types/react@18.3.11)(react@18.3.1)
     optionalDependencies:
@@ -19738,7 +19748,7 @@ snapshots:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.3.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -20211,7 +20221,7 @@ snapshots:
 
   rxjs@7.8.1:
     dependencies:
-      tslib: 2.6.3
+      tslib: 2.8.1
 
   safe-buffer@5.1.2: {}
 
@@ -20533,11 +20543,11 @@ snapshots:
     dependencies:
       internal-slot: 1.0.7
 
-  storybook@8.6.15(prettier@3.3.3):
+  storybook@8.6.15(prettier@3.9.6):
     dependencies:
-      '@storybook/core': 8.6.15(prettier@3.3.3)(storybook@8.6.15(prettier@3.3.3))
+      '@storybook/core': 8.6.15(prettier@3.9.6)(storybook@8.6.15(prettier@3.9.6))
     optionalDependencies:
-      prettier: 3.3.3
+      prettier: 3.9.6
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -20889,6 +20899,8 @@ snapshots:
 
   tslib@2.6.3: {}
 
+  tslib@2.8.1: {}
+
   tsup@8.1.0(@swc/core@1.5.24(@swc/helpers@0.5.13))(postcss@8.4.47)(typescript@5.5.2):
     dependencies:
       bundle-require: 4.2.1(esbuild@0.21.5)
@@ -21168,7 +21180,7 @@ snapshots:
   use-callback-ref@1.3.2(@types/react@18.3.11)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -21176,7 +21188,7 @@ snapshots:
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1
-      tslib: 2.6.3
+      tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.3.11
 
@@ -21741,7 +21753,7 @@ snapshots:
 
   zod@3.25.58: {}
 
-  zrender@5.6.1:
+  zrender@6.1.0:
     dependencies:
       tslib: 2.3.0
 


### PR DESCRIPTION
## Summary

[Arnica warning on another PR](https://github.com/vtex/admin-platform/pull/913#discussion_r3844125293):

<img width="697" height="819" alt="image" src="https://github.com/user-attachments/assets/f46a2cc5-19bf-4fb3-b5c8-e2e14c1dbcc3" />


## Examples

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart layout handling so axis labels remain fully visible without affecting the chart’s outer bounds.

* **Improvements**
  * Updated the charting library to a newer version for improved compatibility and rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->