### PR TITLE
fix(icons): remove border box from IconArrowUpSmall

### DIFF
--- a/packages/shoreline/src/icons/arrow-up-small.tsx
+++ b/packages/shoreline/src/icons/arrow-up-small.tsx
@@ -19,12 +19,6 @@ export const IconArrowUpSmall = forwardRef<
       {...props}
     >
       <path
-        d="M0.0625 0.0625H15.9375V15.9375H0.0625V0.0625Z"
-        vectorEffect="non-scaling-stroke"
-        stroke="currentColor"
-        strokeWidth="0.125"
-      />
-      <path
         d="M8 13.5V2.5"
         vectorEffect="non-scaling-stroke"
         stroke="currentColor"


### PR DESCRIPTION
## Summary

`IconArrowUpSmall` had a stray `<path>` drawing a `0.125`px border box around the `16×16` viewBox:

```tsx
<path
  d="M0.0625 0.0625H15.9375V15.9375H0.0625V0.0625Z"
  vectorEffect="non-scaling-stroke"
  stroke="currentColor"
  strokeWidth="0.125"
/>
```

Its `IconArrowDownSmall` counterpart has no such border. This removed the extra path so both small arrow icons render consistently — just the arrow, no surrounding box.

## Changes

- `packages/shoreline/src/icons/arrow-up-small.tsx` — removed the border `<path>`.

## Session cost

- Total cost: $0.58 (computed from token usage × huawei/glm-5.2 rates; the vision model has no cost configured so the session-cost script reported $0.00)
- Agent pi 0.84.2, model huawei/glm-5.2-vision (reasoning: off), 26 assistant turns
- Token breakdown: 389K input · 7.8K output · 3.5K reasoning · 0 cache-read (~397K total)